### PR TITLE
chore: removing node7, adding nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,13 @@
----
-# "Include" for unit tests definition.
-unit_tests: &unit_tests
-  steps:
-    - checkout
-    - run:
-        name: Install modules and dependencies.
-        command: npm install
-    - run:
-        name: Run unit tests.
-        command: npm test
-    - run:
-        name: Submit coverage data to codecov.
-        command: node_modules/.bin/codecov
-        when: always
-
 version: 2.0
 workflows:
   version: 2
   tests:
-    jobs:
+    jobs: &workflow_jobs
       - node4:
           filters:
             tags:
               only: /.*/
       - node6:
-          filters:
-            tags:
-              only: /.*/
-      - node7:
           filters:
             tags:
               only: /.*/
@@ -43,7 +23,6 @@ workflows:
           requires:
             - node4
             - node6
-            - node7
             - node8
             - node9
           filters:
@@ -53,7 +32,6 @@ workflows:
           requires:
             - node4
             - node6
-            - node7
             - node8
             - node9
           filters:
@@ -78,17 +56,35 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v[\d.]+$/
-
+  nightly:
+    triggers:
+      - schedule:
+          cron: 0 7 * * *
+          filters:
+            branches:
+              only: master
+    jobs: *workflow_jobs
 jobs:
   node4:
     docker:
       - image: node:4
         user: node
-    steps:
+    steps: &unit_tests_steps
       - checkout
+      - run: &remove_package_lock
+          name: Remove package-lock.json if needed.
+          command: |
+            WORKFLOW_NAME=`python .circleci/get_workflow_name.py`
+            echo "Workflow name: $WORKFLOW_NAME"
+            if [ "$WORKFLOW_NAME" = "nightly" ]; then
+              echo "Nightly build detected, removing package-lock.json."
+              rm -f package-lock.json samples/package-lock.json
+            else
+              echo "Not a nightly build, skipping this step."
+            fi
       - run:
           name: Install modules and dependencies.
-          command: npm install --unsafe-perm
+          command: npm install
       - run:
           name: Run unit tests.
           command: npm test
@@ -98,31 +94,26 @@ jobs:
           when: always
   node6:
     docker:
-      - image: node:6
+      - image: 'node:6'
         user: node
-    <<: *unit_tests
-  node7:
-    docker:
-      - image: node:7
-        user: node
-    <<: *unit_tests
+    steps: *unit_tests_steps
   node8:
     docker:
-      - image: node:8
+      - image: 'node:8'
         user: node
-    <<: *unit_tests
+    steps: *unit_tests_steps
   node9:
     docker:
-      - image: node:9
+      - image: 'node:9'
         user: node
-    <<: *unit_tests
-
+    steps: *unit_tests_steps
   lint:
     docker:
       - image: node:8
         user: node
     steps:
       - checkout
+      - run: *remove_package_lock
       - run:
           name: Install modules and dependencies.
           command: |
@@ -152,6 +143,7 @@ jobs:
         user: node
     steps:
       - checkout
+      - run: *remove_package_lock
       - run:
           name: Install modules and dependencies.
           command: npm install
@@ -165,6 +157,7 @@ jobs:
         user: node
     steps:
       - checkout
+      - run: *remove_package_lock
       - run:
           name: Decrypt credentials.
           command: |
@@ -200,32 +193,6 @@ jobs:
           command: rm .circleci/key.json
           when: always
     working_directory: /home/node/dialogflow-samples
-
-  system_tests:
-    docker:
-      - image: node:8
-        user: node
-    steps:
-      - checkout
-      - run:
-          name: Decrypt credentials.
-          command: |
-            openssl aes-256-cbc -d -in .circleci/key.json.enc \
-                -out .circleci/key.json \
-                -k "${SYSTEM_TESTS_ENCRYPTION_KEY}"
-      - run:
-          name: Install modules and dependencies.
-          command: npm install
-      - run:
-          name: Run system tests.
-          command: npm run system-test
-          environment:
-            GOOGLE_APPLICATION_CREDENTIALS: .circleci/key.json
-      - run:
-          name: Remove unencrypted key.
-          command: rm .circleci/key.json
-          when: always
-
   publish_npm:
     docker:
       - image: node:8

--- a/.circleci/get_workflow_name.py
+++ b/.circleci/get_workflow_name.py
@@ -1,0 +1,67 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Get workflow name for the current build using CircleCI API.
+Would be great if this information is available in one of
+CircleCI environment variables, but it's not there.
+https://circleci.ideas.aha.io/ideas/CCI-I-295
+"""
+
+import json
+import os
+import sys
+import urllib2
+
+
+def main():
+    try:
+        username = os.environ['CIRCLE_PROJECT_USERNAME']
+        reponame = os.environ['CIRCLE_PROJECT_REPONAME']
+        build_num = os.environ['CIRCLE_BUILD_NUM']
+    except:
+        sys.stderr.write(
+            'Looks like we are not inside CircleCI container. Exiting...\n')
+        return 1
+
+    try:
+        request = urllib2.Request(
+            "https://circleci.com/api/v1.1/project/github/%s/%s/%s" %
+            (username, reponame, build_num),
+            headers={"Accept": "application/json"})
+        contents = urllib2.urlopen(request).read()
+    except:
+        sys.stderr.write('Cannot query CircleCI API. Exiting...\n')
+        return 1
+
+    try:
+        build_info = json.loads(contents)
+    except:
+        sys.stderr.write(
+            'Cannot parse JSON received from CircleCI API. Exiting...\n')
+        return 1
+
+    try:
+        workflow_name = build_info['workflows']['workflow_name']
+    except:
+        sys.stderr.write(
+            'Cannot get workflow name from CircleCI build info. Exiting...\n')
+        return 1
+
+    print workflow_name
+    return 0
+
+
+retval = main()
+exit(retval)


### PR DESCRIPTION
Several changes to CircleCI configuration:
- removed `node7` as it's EOLed long time ago;
- added nightly builds workflow, running every day at midnight Pacific time;
- removed `system-tests` task that was not run anyway (no systems tests are configured for this library).

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
