### PR TITLE
chore: adding config for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "pinVersions": false,
+  "rebaseStalePrs": true,
+  "schedule": [
+    "after 10pm and before 5am"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "recreateClosed": true,
+    "schedule": [
+      "before 10am on tuesday"
+    ]
+  },
+  "gitAuthor": null
+}


### PR DESCRIPTION
@lukesneeringer Could you please enable [Renovate](https://renovateapp.com/) for this repo? This PR adds some configuration to begin with. We have issues with packages being out of date and should enable either Renovate or GreenKeeper, and I vote for Renovate this time :)

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
