### PR TITLE
chore: update dependency for google-gax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
         "request": "2.85.0",
         "retry-request": "3.3.1",
         "split-array-stream": "1.0.3",
-        "stream-events": "1.0.2",
+        "stream-events": "1.0.3",
         "string-format-obj": "1.1.1",
         "through2": "2.0.3"
       },
@@ -146,7 +146,7 @@
           "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
           "dev": true,
           "requires": {
-            "node-forge": "0.7.4"
+            "node-forge": "0.7.5"
           }
         },
         "gtoken": {
@@ -170,9 +170,9 @@
       }
     },
     "@google-cloud/nodejs-repo-tools": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@google-cloud/nodejs-repo-tools/-/nodejs-repo-tools-2.2.4.tgz",
-      "integrity": "sha512-yHxW7JvhnqgoIftv6dAn1r/9AEcPuumD0xXggdYHmDeyf38OMYyjTk92gP9vflTOee1JhM0vOarwGrlKYUbmnQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/nodejs-repo-tools/-/nodejs-repo-tools-2.2.6.tgz",
+      "integrity": "sha512-bDEgNBAJ8kfYWrpifg+D7rXs8NUBUUeu2I6NWkcL9IOXg86rblu7xnhFHRxBMcvytJ+7WY4pvkCLxO1v3QBsXg==",
       "dev": true,
       "requires": {
         "ava": "0.25.0",
@@ -250,8 +250,7 @@
           "dependencies": {
             "align-text": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2",
@@ -261,26 +260,22 @@
             },
             "amdefine": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-              "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+              "bundled": true,
               "dev": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "bundled": true,
               "dev": true
             },
             "ansi-styles": {
               "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "bundled": true,
               "dev": true
             },
             "append-transform": {
               "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-              "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "default-require-extensions": "1.0.0"
@@ -288,14 +283,12 @@
             },
             "archy": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+              "bundled": true,
               "dev": true
             },
             "arr-diff": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-              "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "arr-flatten": "1.1.0"
@@ -303,32 +296,27 @@
             },
             "arr-flatten": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-              "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+              "bundled": true,
               "dev": true
             },
             "array-unique": {
               "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-              "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+              "bundled": true,
               "dev": true
             },
             "arrify": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-              "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+              "bundled": true,
               "dev": true
             },
             "async": {
               "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+              "bundled": true,
               "dev": true
             },
             "babel-code-frame": {
               "version": "6.26.0",
-              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-              "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "chalk": "1.1.3",
@@ -338,8 +326,7 @@
             },
             "babel-generator": {
               "version": "6.26.0",
-              "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-              "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "babel-messages": "6.23.0",
@@ -354,8 +341,7 @@
             },
             "babel-messages": {
               "version": "6.23.0",
-              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-              "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "babel-runtime": "6.26.0"
@@ -363,8 +349,7 @@
             },
             "babel-runtime": {
               "version": "6.26.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-              "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "core-js": "2.5.3",
@@ -373,8 +358,7 @@
             },
             "babel-template": {
               "version": "6.26.0",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-              "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "babel-runtime": "6.26.0",
@@ -386,8 +370,7 @@
             },
             "babel-traverse": {
               "version": "6.26.0",
-              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-              "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "babel-code-frame": "6.26.0",
@@ -403,8 +386,7 @@
             },
             "babel-types": {
               "version": "6.26.0",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-              "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "babel-runtime": "6.26.0",
@@ -415,20 +397,17 @@
             },
             "babylon": {
               "version": "6.18.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-              "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+              "bundled": true,
               "dev": true
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+              "bundled": true,
               "dev": true
             },
             "brace-expansion": {
               "version": "1.1.8",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-              "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "balanced-match": "1.0.0",
@@ -437,8 +416,7 @@
             },
             "braces": {
               "version": "1.8.5",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-              "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "expand-range": "1.8.2",
@@ -448,14 +426,12 @@
             },
             "builtin-modules": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+              "bundled": true,
               "dev": true
             },
             "caching-transform": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-              "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "md5-hex": "1.3.0",
@@ -465,15 +441,13 @@
             },
             "camelcase": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-              "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "center-align": {
               "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-              "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -483,8 +457,7 @@
             },
             "chalk": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-styles": "2.2.1",
@@ -496,8 +469,7 @@
             },
             "cliui": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-              "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -508,8 +480,7 @@
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                  "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 }
@@ -517,38 +488,32 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+              "bundled": true,
               "dev": true
             },
             "commondir": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-              "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+              "bundled": true,
               "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+              "bundled": true,
               "dev": true
             },
             "convert-source-map": {
               "version": "1.5.1",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-              "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+              "bundled": true,
               "dev": true
             },
             "core-js": {
               "version": "2.5.3",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-              "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+              "bundled": true,
               "dev": true
             },
             "cross-spawn": {
               "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-              "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lru-cache": "4.1.1",
@@ -557,8 +522,7 @@
             },
             "debug": {
               "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ms": "2.0.0"
@@ -566,20 +530,17 @@
             },
             "debug-log": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-              "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+              "bundled": true,
               "dev": true
             },
             "decamelize": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+              "bundled": true,
               "dev": true
             },
             "default-require-extensions": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-              "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "strip-bom": "2.0.0"
@@ -587,8 +548,7 @@
             },
             "detect-indent": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-              "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "repeating": "2.0.1"
@@ -596,8 +556,7 @@
             },
             "error-ex": {
               "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-              "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-arrayish": "0.2.1"
@@ -605,20 +564,17 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "bundled": true,
               "dev": true
             },
             "esutils": {
               "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+              "bundled": true,
               "dev": true
             },
             "execa": {
               "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-              "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "cross-spawn": "5.1.0",
@@ -632,8 +588,7 @@
               "dependencies": {
                 "cross-spawn": {
                   "version": "5.1.0",
-                  "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-                  "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lru-cache": "4.1.1",
@@ -645,8 +600,7 @@
             },
             "expand-brackets": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-              "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-posix-bracket": "0.1.1"
@@ -654,8 +608,7 @@
             },
             "expand-range": {
               "version": "1.8.2",
-              "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-              "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "fill-range": "2.2.3"
@@ -663,8 +616,7 @@
             },
             "extglob": {
               "version": "0.3.2",
-              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-              "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extglob": "1.0.0"
@@ -672,14 +624,12 @@
             },
             "filename-regex": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-              "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+              "bundled": true,
               "dev": true
             },
             "fill-range": {
               "version": "2.2.3",
-              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-              "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-number": "2.1.0",
@@ -691,8 +641,7 @@
             },
             "find-cache-dir": {
               "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-              "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "commondir": "1.0.1",
@@ -702,8 +651,7 @@
             },
             "find-up": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "locate-path": "2.0.0"
@@ -711,14 +659,12 @@
             },
             "for-in": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-              "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+              "bundled": true,
               "dev": true
             },
             "for-own": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-              "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "for-in": "1.0.2"
@@ -726,8 +672,7 @@
             },
             "foreground-child": {
               "version": "1.5.6",
-              "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-              "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "cross-spawn": "4.0.2",
@@ -736,26 +681,22 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+              "bundled": true,
               "dev": true
             },
             "get-caller-file": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-              "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+              "bundled": true,
               "dev": true
             },
             "get-stream": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+              "bundled": true,
               "dev": true
             },
             "glob": {
               "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "fs.realpath": "1.0.0",
@@ -768,8 +709,7 @@
             },
             "glob-base": {
               "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-              "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "glob-parent": "2.0.0",
@@ -778,8 +718,7 @@
             },
             "glob-parent": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-              "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-glob": "2.0.1"
@@ -787,20 +726,17 @@
             },
             "globals": {
               "version": "9.18.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-              "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+              "bundled": true,
               "dev": true
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+              "bundled": true,
               "dev": true
             },
             "handlebars": {
               "version": "4.0.11",
-              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-              "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "async": "1.5.2",
@@ -811,8 +747,7 @@
               "dependencies": {
                 "source-map": {
                   "version": "0.4.4",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                  "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "amdefine": "1.0.1"
@@ -822,8 +757,7 @@
             },
             "has-ansi": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-regex": "2.1.1"
@@ -831,26 +765,22 @@
             },
             "has-flag": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+              "bundled": true,
               "dev": true
             },
             "hosted-git-info": {
               "version": "2.5.0",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-              "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+              "bundled": true,
               "dev": true
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+              "bundled": true,
               "dev": true
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "once": "1.4.0",
@@ -859,14 +789,12 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "bundled": true,
               "dev": true
             },
             "invariant": {
               "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-              "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "loose-envify": "1.3.1"
@@ -874,26 +802,22 @@
             },
             "invert-kv": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-              "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+              "bundled": true,
               "dev": true
             },
             "is-arrayish": {
               "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-              "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+              "bundled": true,
               "dev": true
             },
             "is-buffer": {
               "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+              "bundled": true,
               "dev": true
             },
             "is-builtin-module": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "builtin-modules": "1.1.1"
@@ -901,14 +825,12 @@
             },
             "is-dotfile": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-              "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+              "bundled": true,
               "dev": true
             },
             "is-equal-shallow": {
               "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-              "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-primitive": "2.0.0"
@@ -916,20 +838,17 @@
             },
             "is-extendable": {
               "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-              "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+              "bundled": true,
               "dev": true
             },
             "is-extglob": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+              "bundled": true,
               "dev": true
             },
             "is-finite": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-              "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "number-is-nan": "1.0.1"
@@ -937,8 +856,7 @@
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "number-is-nan": "1.0.1"
@@ -946,8 +864,7 @@
             },
             "is-glob": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extglob": "1.0.0"
@@ -955,8 +872,7 @@
             },
             "is-number": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-              "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -964,44 +880,37 @@
             },
             "is-posix-bracket": {
               "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-              "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+              "bundled": true,
               "dev": true
             },
             "is-primitive": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-              "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+              "bundled": true,
               "dev": true
             },
             "is-stream": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+              "bundled": true,
               "dev": true
             },
             "is-utf8": {
               "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+              "bundled": true,
               "dev": true
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "bundled": true,
               "dev": true
             },
             "isexe": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+              "bundled": true,
               "dev": true
             },
             "isobject": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "isarray": "1.0.0"
@@ -1009,14 +918,12 @@
             },
             "istanbul-lib-coverage": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-              "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
+              "bundled": true,
               "dev": true
             },
             "istanbul-lib-hook": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
-              "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "append-transform": "0.4.0"
@@ -1024,8 +931,7 @@
             },
             "istanbul-lib-instrument": {
               "version": "1.9.1",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
-              "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "babel-generator": "6.26.0",
@@ -1039,8 +945,7 @@
             },
             "istanbul-lib-report": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
-              "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "istanbul-lib-coverage": "1.1.1",
@@ -1051,8 +956,7 @@
               "dependencies": {
                 "supports-color": {
                   "version": "3.2.3",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                  "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "has-flag": "1.0.0"
@@ -1062,8 +966,7 @@
             },
             "istanbul-lib-source-maps": {
               "version": "1.2.2",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
-              "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "debug": "3.1.0",
@@ -1075,8 +978,7 @@
               "dependencies": {
                 "debug": {
                   "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                  "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ms": "2.0.0"
@@ -1086,8 +988,7 @@
             },
             "istanbul-reports": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
-              "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "handlebars": "4.0.11"
@@ -1095,20 +996,17 @@
             },
             "js-tokens": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-              "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+              "bundled": true,
               "dev": true
             },
             "jsesc": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-              "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+              "bundled": true,
               "dev": true
             },
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-buffer": "1.1.6"
@@ -1116,15 +1014,13 @@
             },
             "lazy-cache": {
               "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-              "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "lcid": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-              "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "invert-kv": "1.0.0"
@@ -1132,8 +1028,7 @@
             },
             "load-json-file": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-              "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
@@ -1145,8 +1040,7 @@
             },
             "locate-path": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-              "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "p-locate": "2.0.0",
@@ -1155,28 +1049,24 @@
               "dependencies": {
                 "path-exists": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                  "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "lodash": {
               "version": "4.17.4",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+              "bundled": true,
               "dev": true
             },
             "longest": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+              "bundled": true,
               "dev": true
             },
             "loose-envify": {
               "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-              "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "js-tokens": "3.0.2"
@@ -1184,8 +1074,7 @@
             },
             "lru-cache": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-              "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "pseudomap": "1.0.2",
@@ -1194,8 +1083,7 @@
             },
             "md5-hex": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-              "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "md5-o-matic": "0.1.1"
@@ -1203,14 +1091,12 @@
             },
             "md5-o-matic": {
               "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-              "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+              "bundled": true,
               "dev": true
             },
             "mem": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-              "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "mimic-fn": "1.1.0"
@@ -1218,8 +1104,7 @@
             },
             "merge-source-map": {
               "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-              "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "source-map": "0.5.7"
@@ -1227,8 +1112,7 @@
             },
             "micromatch": {
               "version": "2.3.11",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-              "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "arr-diff": "2.0.0",
@@ -1248,14 +1132,12 @@
             },
             "mimic-fn": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-              "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+              "bundled": true,
               "dev": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "brace-expansion": "1.1.8"
@@ -1263,14 +1145,12 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "bundled": true,
               "dev": true
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "minimist": "0.0.8"
@@ -1278,14 +1158,12 @@
             },
             "ms": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "bundled": true,
               "dev": true
             },
             "normalize-package-data": {
               "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-              "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "hosted-git-info": "2.5.0",
@@ -1296,8 +1174,7 @@
             },
             "normalize-path": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "remove-trailing-separator": "1.1.0"
@@ -1305,8 +1182,7 @@
             },
             "npm-run-path": {
               "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-              "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "path-key": "2.0.1"
@@ -1314,20 +1190,17 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+              "bundled": true,
               "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+              "bundled": true,
               "dev": true
             },
             "object.omit": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-              "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "for-own": "0.1.5",
@@ -1336,8 +1209,7 @@
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "wrappy": "1.0.2"
@@ -1345,8 +1217,7 @@
             },
             "optimist": {
               "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "minimist": "0.0.8",
@@ -1355,14 +1226,12 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+              "bundled": true,
               "dev": true
             },
             "os-locale": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-              "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "execa": "0.7.0",
@@ -1372,20 +1241,17 @@
             },
             "p-finally": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-              "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+              "bundled": true,
               "dev": true
             },
             "p-limit": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-              "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+              "bundled": true,
               "dev": true
             },
             "p-locate": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-              "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "p-limit": "1.1.0"
@@ -1393,8 +1259,7 @@
             },
             "parse-glob": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-              "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "glob-base": "0.3.0",
@@ -1405,8 +1270,7 @@
             },
             "parse-json": {
               "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-              "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "error-ex": "1.3.1"
@@ -1414,8 +1278,7 @@
             },
             "path-exists": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "pinkie-promise": "2.0.1"
@@ -1423,26 +1286,22 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+              "bundled": true,
               "dev": true
             },
             "path-key": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+              "bundled": true,
               "dev": true
             },
             "path-parse": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-              "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+              "bundled": true,
               "dev": true
             },
             "path-type": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-              "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
@@ -1452,20 +1311,17 @@
             },
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "bundled": true,
               "dev": true
             },
             "pinkie": {
               "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+              "bundled": true,
               "dev": true
             },
             "pinkie-promise": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "pinkie": "2.0.4"
@@ -1473,8 +1329,7 @@
             },
             "pkg-dir": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-              "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "find-up": "1.1.2"
@@ -1482,8 +1337,7 @@
               "dependencies": {
                 "find-up": {
                   "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                  "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "path-exists": "2.1.0",
@@ -1494,20 +1348,17 @@
             },
             "preserve": {
               "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-              "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+              "bundled": true,
               "dev": true
             },
             "pseudomap": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+              "bundled": true,
               "dev": true
             },
             "randomatic": {
               "version": "1.1.7",
-              "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-              "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-number": "3.0.0",
@@ -1516,8 +1367,7 @@
               "dependencies": {
                 "is-number": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                  "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "kind-of": "3.2.2"
@@ -1525,8 +1375,7 @@
                   "dependencies": {
                     "kind-of": {
                       "version": "3.2.2",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "is-buffer": "1.1.6"
@@ -1536,8 +1385,7 @@
                 },
                 "kind-of": {
                   "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                  "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
@@ -1547,8 +1395,7 @@
             },
             "read-pkg": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-              "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "load-json-file": "1.1.0",
@@ -1558,8 +1405,7 @@
             },
             "read-pkg-up": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "find-up": "1.1.2",
@@ -1568,8 +1414,7 @@
               "dependencies": {
                 "find-up": {
                   "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                  "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "path-exists": "2.1.0",
@@ -1580,14 +1425,12 @@
             },
             "regenerator-runtime": {
               "version": "0.11.1",
-              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-              "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+              "bundled": true,
               "dev": true
             },
             "regex-cache": {
               "version": "0.4.4",
-              "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-              "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-equal-shallow": "0.1.3"
@@ -1595,26 +1438,22 @@
             },
             "remove-trailing-separator": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-              "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+              "bundled": true,
               "dev": true
             },
             "repeat-element": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-              "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+              "bundled": true,
               "dev": true
             },
             "repeat-string": {
               "version": "1.6.1",
-              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-              "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+              "bundled": true,
               "dev": true
             },
             "repeating": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-              "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-finite": "1.0.2"
@@ -1622,26 +1461,22 @@
             },
             "require-directory": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+              "bundled": true,
               "dev": true
             },
             "require-main-filename": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+              "bundled": true,
               "dev": true
             },
             "resolve-from": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-              "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+              "bundled": true,
               "dev": true
             },
             "right-align": {
               "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-              "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -1650,8 +1485,7 @@
             },
             "rimraf": {
               "version": "2.6.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-              "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "glob": "7.1.2"
@@ -1659,20 +1493,17 @@
             },
             "semver": {
               "version": "5.4.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+              "bundled": true,
               "dev": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+              "bundled": true,
               "dev": true
             },
             "shebang-command": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "shebang-regex": "1.0.0"
@@ -1680,32 +1511,27 @@
             },
             "shebang-regex": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+              "bundled": true,
               "dev": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+              "bundled": true,
               "dev": true
             },
             "slide": {
               "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+              "bundled": true,
               "dev": true
             },
             "source-map": {
               "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "bundled": true,
               "dev": true
             },
             "spawn-wrap": {
               "version": "1.4.2",
-              "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
-              "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "foreground-child": "1.5.6",
@@ -1718,8 +1544,7 @@
             },
             "spdx-correct": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "spdx-license-ids": "1.2.2"
@@ -1727,20 +1552,17 @@
             },
             "spdx-expression-parse": {
               "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-              "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+              "bundled": true,
               "dev": true
             },
             "spdx-license-ids": {
               "version": "1.2.2",
-              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-              "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+              "bundled": true,
               "dev": true
             },
             "string-width": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-fullwidth-code-point": "2.0.0",
@@ -1749,20 +1571,17 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                  "bundled": true,
                   "dev": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                  "bundled": true,
                   "dev": true
                 },
                 "strip-ansi": {
                   "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                  "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi-regex": "3.0.0"
@@ -1772,8 +1591,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-regex": "2.1.1"
@@ -1781,8 +1599,7 @@
             },
             "strip-bom": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-utf8": "0.2.1"
@@ -1790,20 +1607,17 @@
             },
             "strip-eof": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+              "bundled": true,
               "dev": true
             },
             "supports-color": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "bundled": true,
               "dev": true
             },
             "test-exclude": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-              "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "arrify": "1.0.1",
@@ -1815,20 +1629,17 @@
             },
             "to-fast-properties": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-              "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+              "bundled": true,
               "dev": true
             },
             "trim-right": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-              "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+              "bundled": true,
               "dev": true
             },
             "uglify-js": {
               "version": "2.8.29",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-              "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -1839,8 +1650,7 @@
               "dependencies": {
                 "yargs": {
                   "version": "3.10.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                  "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -1854,15 +1664,13 @@
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-              "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "spdx-correct": "1.0.2",
@@ -1871,8 +1679,7 @@
             },
             "which": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-              "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "isexe": "2.0.0"
@@ -1880,27 +1687,23 @@
             },
             "which-module": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+              "bundled": true,
               "dev": true
             },
             "window-size": {
               "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-              "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "wordwrap": {
               "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+              "bundled": true,
               "dev": true
             },
             "wrap-ansi": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-              "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "string-width": "1.0.2",
@@ -1909,8 +1712,7 @@
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "code-point-at": "1.1.0",
@@ -1922,14 +1724,12 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "bundled": true,
               "dev": true
             },
             "write-file-atomic": {
               "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-              "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
@@ -1939,20 +1739,17 @@
             },
             "y18n": {
               "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+              "bundled": true,
               "dev": true
             },
             "yallist": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+              "bundled": true,
               "dev": true
             },
             "yargs": {
               "version": "10.0.3",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-              "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "cliui": "3.2.0",
@@ -1971,8 +1768,7 @@
               "dependencies": {
                 "cliui": {
                   "version": "3.2.0",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                  "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "string-width": "1.0.2",
@@ -1982,8 +1778,7 @@
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "code-point-at": "1.1.0",
@@ -1997,8 +1792,7 @@
             },
             "yargs-parser": {
               "version": "8.0.0",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
-              "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "camelcase": "4.1.0"
@@ -2006,8 +1800,7 @@
               "dependencies": {
                 "camelcase": {
                   "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                  "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -2112,6 +1905,15 @@
         }
       }
     },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "requires": {
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
+      }
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2187,9 +1989,9 @@
       "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA=="
     },
     "@types/node": {
-      "version": "8.9.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.5.tgz",
-      "integrity": "sha512-jRHfWsvyMtXdbhnz5CVHxaBgnV6duZnPlQuRSo/dm/GnmikNcmZhxIES4E9OZjUmQ8C+HCl4KJux+cXN/ErGDQ=="
+      "version": "8.10.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.3.tgz",
+      "integrity": "sha512-vjiRZkhKEyZndtFOz/FtIp0CqPbgOOki8o9IcPOLTqlzcnvFLToYdERshLaI6TCz7pDWoKlmvgftqB4xlltn9g=="
     },
     "acorn": {
       "version": "4.0.13",
@@ -2244,6 +2046,17 @@
         "kind-of": "3.2.2",
         "longest": "1.0.1",
         "repeat-string": "1.6.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "amdefine": {
@@ -2295,9 +2108,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
     "ansi-regex": {
@@ -2322,6 +2135,97 @@
       "requires": {
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        }
       }
     },
     "argparse": {
@@ -2333,11 +2237,6 @@
         "sprintf-js": "1.0.3"
       }
     },
-    "arguejs": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/arguejs/-/arguejs-0.2.3.tgz",
-      "integrity": "sha1-tvk59f4OPNHz+T4qqSYkJL8xKvc="
-    },
     "argv": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
@@ -2345,13 +2244,9 @@
       "dev": true
     },
     "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "1.1.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-exclude": {
       "version": "1.0.0",
@@ -2362,8 +2257,12 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-differ": {
       "version": "1.0.0",
@@ -2402,10 +2301,9 @@
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "dev": true
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "arrify": {
       "version": "1.0.1",
@@ -2431,6 +2329,11 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+    },
     "async": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
@@ -2450,6 +2353,11 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "atob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw=="
+    },
     "auto-bind": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.2.0.tgz",
@@ -2467,7 +2375,7 @@
         "@ava/write-file-atomic": "2.2.0",
         "@concordance/react": "1.0.0",
         "@ladjs/time-require": "0.1.4",
-        "ansi-escapes": "3.0.0",
+        "ansi-escapes": "3.1.0",
         "ansi-styles": "3.2.1",
         "arr-flatten": "1.1.0",
         "array-union": "1.0.2",
@@ -2485,7 +2393,7 @@
         "clean-stack": "1.3.0",
         "clean-yaml-object": "0.1.0",
         "cli-cursor": "2.1.0",
-        "cli-spinners": "1.1.0",
+        "cli-spinners": "1.3.0",
         "cli-truncate": "1.1.0",
         "co-with-promise": "4.6.0",
         "code-excerpt": "2.1.1",
@@ -2544,7 +2452,7 @@
         "supports-color": "5.3.0",
         "trim-off-newlines": "1.0.1",
         "unique-temp-dir": "1.0.0",
-        "update-notifier": "2.3.0"
+        "update-notifier": "2.4.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2552,6 +2460,15 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "globby": {
           "version": "6.1.0",
@@ -2693,17 +2610,6 @@
         "private": "0.1.8",
         "slash": "1.0.0",
         "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "babel-generator": {
@@ -2858,7 +2764,7 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "espower-location-detector": "1.0.0",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -3005,7 +2911,7 @@
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.5",
         "mkdirp": "0.5.1",
@@ -3029,7 +2935,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -3061,17 +2967,6 @@
         "globals": "9.18.0",
         "invariant": "2.2.4",
         "lodash": "4.17.5"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "babel-types": {
@@ -3096,6 +2991,30 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        }
+      }
     },
     "base64url": {
       "version": "2.0.0",
@@ -3195,14 +3114,40 @@
       }
     },
     "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+      "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "kind-of": "6.0.2",
+        "repeat-element": "1.1.2",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
       }
     },
     "browser-stdout": {
@@ -3249,6 +3194,22 @@
         }
       }
     },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      }
+    },
     "cacheable-request": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
@@ -3262,6 +3223,14 @@
         "lowercase-keys": "1.0.0",
         "normalize-url": "2.0.1",
         "responselike": "1.0.2"
+      },
+      "dependencies": {
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+          "dev": true
+        }
       }
     },
     "caching-transform": {
@@ -3303,11 +3272,16 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "deep-equal": "1.0.1",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
       }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "call-signature": {
       "version": "0.0.2",
@@ -3407,6 +3381,32 @@
         "is-glob": "2.0.1",
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
       }
     },
     "ci-info": {
@@ -3420,6 +3420,78 @@
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
     },
     "clean-stack": {
       "version": "1.3.0",
@@ -3449,9 +3521,9 @@
       }
     },
     "cli-spinners": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
-      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.0.tgz",
+      "integrity": "sha512-ahr3q/EW26uLN3vqBaDQS4g1rUwKMbVSTRlyfyoY06VwwSJmMYRxhT3FTAiTz9Yam6OOb1e0ldwvbsnuThvuzA==",
       "dev": true
     },
     "cli-truncate": {
@@ -3710,6 +3782,15 @@
         }
       }
     },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
+    },
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
@@ -3768,8 +3849,7 @@
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -3784,7 +3864,7 @@
       "requires": {
         "buffer-from": "1.0.0",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
       }
     },
@@ -3819,9 +3899,9 @@
       }
     },
     "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
         "dot-prop": "4.2.0",
@@ -3850,6 +3930,11 @@
       "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
       "dev": true
     },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
     "core-assert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
@@ -3861,9 +3946,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+      "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3929,7 +4014,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.41"
+        "es5-ext": "0.10.42"
       }
     },
     "dashdash": {
@@ -3947,9 +4032,9 @@
       "dev": true
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -3962,8 +4047,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -4001,6 +4085,15 @@
         "object-keys": "1.0.11"
       }
     },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "requires": {
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
+      }
+    },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
@@ -4009,7 +4102,7 @@
       "requires": {
         "globby": "5.0.0",
         "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
@@ -4158,11 +4251,10 @@
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
       "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
-      "dev": true,
       "requires": {
         "end-of-stream": "1.4.1",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "stream-shift": "1.0.0"
       }
     },
@@ -4194,7 +4286,7 @@
       "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.3.tgz",
       "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "empower-core": "0.6.2"
       }
     },
@@ -4213,14 +4305,13 @@
       "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.3"
+        "core-js": "2.5.4"
       }
     },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "dev": true,
       "requires": {
         "once": "1.4.0"
       }
@@ -4253,9 +4344,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.41",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.41.tgz",
-      "integrity": "sha512-MYK02wXfwTMie5TEJWPolgOsXEmz7wKCQaGzgmRjZOoV6VLG8I5dSv2bn6AOClXhK64gnSQTQ9W9MKvx87J4gw==",
+      "version": "0.10.42",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -4276,7 +4367,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-symbol": "3.1.1"
       }
     },
@@ -4287,7 +4378,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -4301,7 +4392,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -4314,7 +4405,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41"
+        "es5-ext": "0.10.42"
       }
     },
     "es6-weak-map": {
@@ -4324,7 +4415,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -4394,9 +4485,9 @@
       }
     },
     "eslint": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.0.tgz",
-      "integrity": "sha512-r83L5CuqaocDvfwdojbz68b6tCUk8KJkqfppO+gmSAQqYCzTr0bCSMu6A6yFCLKG65j5eKcKUw4Cw4Yl4gfWkg==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -4409,12 +4500,12 @@
         "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "1.0.0",
         "espree": "3.5.4",
-        "esquery": "1.0.0",
+        "esquery": "1.0.1",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "11.3.0",
+        "globals": "11.4.0",
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
@@ -4430,7 +4521,7 @@
         "path-is-inside": "1.0.2",
         "pluralize": "7.0.0",
         "progress": "2.0.0",
-        "regexpp": "1.0.1",
+        "regexpp": "1.1.0",
         "require-uncached": "1.0.3",
         "semver": "5.5.0",
         "strip-ansi": "4.0.0",
@@ -4445,10 +4536,19 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "globals": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
-          "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+          "version": "11.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+          "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
           "dev": true
         },
         "strip-ansi": {
@@ -4582,7 +4682,7 @@
       "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
       "dev": true,
       "requires": {
-        "is-url": "1.2.3",
+        "is-url": "1.2.4",
         "path-is-absolute": "1.0.1",
         "source-map": "0.5.7",
         "xtend": "4.0.1"
@@ -4644,13 +4744,13 @@
       "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "requires": {
-        "core-js": "2.5.3"
+        "core-js": "2.5.4"
       }
     },
     "esquery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
         "estraverse": "4.2.0"
@@ -4683,7 +4783,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41"
+        "es5-ext": "0.10.42"
       }
     },
     "execa": {
@@ -4702,12 +4802,86 @@
       }
     },
     "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
       }
     },
     "expand-range": {
@@ -4717,6 +4891,48 @@
       "dev": true,
       "requires": {
         "fill-range": "2.2.3"
+      },
+      "dependencies": {
+        "fill-range": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "extend": {
@@ -4724,10 +4940,29 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "requires": {
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
     "external-editor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
@@ -4736,12 +4971,36 @@
       }
     },
     "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "requires": {
-        "is-extglob": "1.0.0"
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
       }
     },
     "extsprintf": {
@@ -4759,6 +5018,18 @@
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
       "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
       "dev": true
+    },
+    "fast-glob": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.0.tgz",
+      "integrity": "sha512-4F75PTznkNtSKs2pbhtBwRkw8sRwa7LfXx5XaQJOe4IQ6yTjceLDTwM5gj1s80R2t/5WeDC1gVfm3jLE+l39Tw==",
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.1",
+        "micromatch": "3.1.10"
+      }
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -4807,16 +5078,24 @@
       }
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
       }
     },
     "find-cache-dir": {
@@ -4863,13 +5142,22 @@
       "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
       "requires": {
         "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
       "version": "0.1.5",
@@ -4906,6 +5194,14 @@
       "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
       "dev": true
     },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "requires": {
+        "map-cache": "0.2.2"
+      }
+    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -4913,7 +5209,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.5"
+        "readable-stream": "2.3.6"
       }
     },
     "fs-extra": {
@@ -5882,6 +6178,11 @@
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -5911,16 +6212,57 @@
       "requires": {
         "glob-parent": "2.0.0",
         "is-glob": "2.0.1"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
       }
     },
     "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        }
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
     },
     "global-dirs": {
       "version": "0.1.1",
@@ -5938,12 +6280,13 @@
       "dev": true
     },
     "globby": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-      "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+      "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
       "requires": {
         "array-union": "1.0.2",
         "dir-glob": "2.0.0",
+        "fast-glob": "2.2.0",
         "glob": "7.1.2",
         "ignore": "3.3.7",
         "pify": "3.0.0",
@@ -5951,13 +6294,13 @@
       }
     },
     "google-auth-library": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.3.2.tgz",
-      "integrity": "sha512-aRz0om4Bs85uyR2Ousk3Gb8Nffx2Sr2RoKts1smg1MhRwrehE1aD1HC4RmprNt1HVJ88IDnQ8biJQ/aXjiIxlQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.4.0.tgz",
+      "integrity": "sha512-vWRx6pJulK7Y5V/Xyr7MPMlx2mWfmrUVbcffZ7hpq8ElFg5S8WY6PvjMovdcr6JfuAwwpAX4R0I1XOcyWuBcUw==",
       "requires": {
         "axios": "0.18.0",
         "gcp-metadata": "0.6.3",
-        "gtoken": "2.2.0",
+        "gtoken": "2.3.0",
         "jws": "3.1.4",
         "lodash.isstring": "4.0.1",
         "lru-cache": "4.1.2",
@@ -5971,24 +6314,24 @@
       "requires": {
         "async": "2.6.0",
         "gcp-metadata": "0.6.3",
-        "google-auth-library": "1.3.2",
+        "google-auth-library": "1.4.0",
         "request": "2.85.0"
       }
     },
     "google-gax": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.14.5.tgz",
-      "integrity": "sha512-3A6KbrtLDavrqZnnzurnSydRIJnyH+2Sm56fAvXciQ/62aEnSDaR43MCgWhtReCLVjeFjBiCEIdX5zV0LVLVBg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.16.0.tgz",
+      "integrity": "sha512-sslPB7USGD8SrVUGlWFIGYVZrgZ6oj+fWUEW3f8Bk43+nxqeLyrNoI3iFBRpjLfwMCEYaXVziWNmatwLRP8azg==",
       "requires": {
+        "duplexify": "3.5.4",
         "extend": "3.0.1",
-        "globby": "7.1.1",
+        "globby": "8.0.1",
         "google-auto-auth": "0.9.7",
-        "google-proto-files": "0.14.2",
-        "grpc": "1.7.3",
-        "is-stream-ended": "0.1.3",
+        "google-proto-files": "0.15.1",
+        "grpc": "1.9.1",
+        "is-stream-ended": "0.1.4",
         "lodash": "4.17.5",
         "protobufjs": "6.8.6",
-        "readable-stream": "2.3.5",
         "through2": "2.0.3"
       }
     },
@@ -5997,19 +6340,33 @@
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
       "integrity": "sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==",
       "requires": {
-        "node-forge": "0.7.4",
+        "node-forge": "0.7.5",
         "pify": "3.0.0"
       }
     },
     "google-proto-files": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.14.2.tgz",
-      "integrity": "sha512-wwm2TIlfTgAjDbjrxAb3akznO7vBM0PRLS6Xf2QfR3L7b0p+szD3iwOW0wMSFl3B0UbLv27hUVk+clePqCVmXA==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.15.1.tgz",
+      "integrity": "sha512-ebtmWgi/ooR5Nl63qRVZZ6VLM6JOb5zTNxTT/ZAU8yfMOdcauoOZNNMOVg0pCmTjqWXeuuVbgPP0CwO5UHHzBQ==",
       "requires": {
         "globby": "7.1.1",
-        "power-assert": "1.4.4",
-        "prettier": "1.11.1",
+        "power-assert": "1.5.0",
         "protobufjs": "6.8.6"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+          "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+          "requires": {
+            "array-union": "1.0.2",
+            "dir-glob": "2.0.0",
+            "glob": "7.1.2",
+            "ignore": "3.3.7",
+            "pify": "3.0.0",
+            "slash": "1.0.0"
+          }
+        }
       }
     },
     "got": {
@@ -6026,7 +6383,7 @@
         "into-stream": "3.1.0",
         "is-retry-allowed": "1.1.0",
         "isurl": "1.0.0",
-        "lowercase-keys": "1.0.0",
+        "lowercase-keys": "1.0.1",
         "mimic-response": "1.0.0",
         "p-cancelable": "0.3.0",
         "p-timeout": "2.0.1",
@@ -6073,11 +6430,10 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.7.3.tgz",
-      "integrity": "sha512-7zXQJlDXMr/ZaDqdaIchgclViyoWo8GQxZSmFUAxR8GwSr28b6/BTgF221WG+2W693jpp74XJ/+I9DcPXsgt9Q==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.9.1.tgz",
+      "integrity": "sha512-WNW3MWMuAoo63AwIlzFE3T0KzzvNBSvOkg67Hm8WhvHNkXFBlIk1QyJRE3Ocm0O5eIwS7JU8Ssota53QR1zllg==",
       "requires": {
-        "arguejs": "0.2.3",
         "lodash": "4.17.5",
         "nan": "2.10.0",
         "node-pre-gyp": "0.6.39",
@@ -6085,14 +6441,12 @@
       },
       "dependencies": {
         "abbrev": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
+          "version": "1.1.1",
+          "bundled": true
         },
         "ajv": {
           "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "bundled": true,
           "requires": {
             "co": "4.6.0",
             "json-stable-stringify": "1.0.1"
@@ -6100,18 +6454,15 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "requires": {
             "delegates": "1.0.0",
             "readable-stream": "2.3.3"
@@ -6119,38 +6470,31 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+          "bundled": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+          "bundled": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+          "bundled": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+          "bundled": true
         },
         "aws4": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+          "bundled": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "bundled": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "tweetnacl": "0.14.5"
@@ -6158,24 +6502,21 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "bundled": true,
           "requires": {
             "inherits": "2.0.3"
           }
         },
         "boom": {
           "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "bundled": true,
           "requires": {
             "hoek": "2.16.3"
           }
         },
         "brace-expansion": {
           "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+          "bundled": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -6183,97 +6524,81 @@
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+          "bundled": true
         },
         "co": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "bundled": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "bundled": true,
           "requires": {
             "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+          "bundled": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "bundled": true,
           "requires": {
             "boom": "2.10.1"
           }
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "bundled": true,
           "requires": {
             "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+              "bundled": true
             }
           }
         },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "bundled": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+          "bundled": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+          "bundled": true
         },
         "detect-libc": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
-          "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE="
+          "version": "1.0.3",
+          "bundled": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "jsbn": "0.1.1"
@@ -6281,23 +6606,19 @@
         },
         "extend": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+          "bundled": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+          "bundled": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+          "bundled": true
         },
         "form-data": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "bundled": true,
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.5",
@@ -6306,13 +6627,11 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+          "bundled": true
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
@@ -6322,8 +6641,7 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "bundled": true,
           "requires": {
             "fstream": "1.0.11",
             "inherits": "2.0.3",
@@ -6332,8 +6650,7 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "requires": {
             "aproba": "1.2.0",
             "console-control-strings": "1.1.0",
@@ -6347,23 +6664,20 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "bundled": true,
           "requires": {
             "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+              "bundled": true
             }
           }
         },
         "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "version": "7.1.2",
+          "bundled": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -6375,18 +6689,15 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+          "bundled": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+          "bundled": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "bundled": true,
           "requires": {
             "ajv": "4.11.8",
             "har-schema": "1.0.5"
@@ -6394,13 +6705,11 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+          "bundled": true
         },
         "hawk": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "bundled": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -6410,13 +6719,11 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+          "bundled": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "bundled": true,
           "requires": {
             "assert-plus": "0.2.0",
             "jsprim": "1.4.1",
@@ -6425,8 +6732,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -6434,70 +6740,58 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "bundled": true
         },
         "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+          "version": "1.3.5",
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+          "bundled": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "bundled": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+          "bundled": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "bundled": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+          "bundled": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "bundled": true,
           "requires": {
             "jsonify": "0.0.0"
           }
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+          "bundled": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+          "bundled": true
         },
         "jsprim": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+          "bundled": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
@@ -6507,83 +6801,71 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+              "bundled": true
             }
           }
         },
         "mime-db": {
           "version": "1.30.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+          "bundled": true
         },
         "mime-types": {
           "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "bundled": true,
           "requires": {
             "mime-db": "1.30.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "requires": {
             "brace-expansion": "1.1.8"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "bundled": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "bundled": true
         },
         "node-pre-gyp": {
           "version": "0.6.39",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
-          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+          "bundled": true,
           "requires": {
-            "detect-libc": "1.0.2",
+            "detect-libc": "1.0.3",
             "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.2",
-            "rc": "1.2.2",
+            "rc": "1.2.4",
             "request": "2.81.0",
             "rimraf": "2.6.2",
-            "semver": "5.4.1",
+            "semver": "5.5.0",
             "tar": "2.2.1",
             "tar-pack": "3.4.1"
-          },
-          "dependencies": {
-            "nopt": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-              "requires": {
-                "abbrev": "1.0.9",
-                "osenv": "0.1.4"
-              }
-            }
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.4"
           }
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
             "console-control-strings": "1.1.0",
@@ -6593,41 +6875,34 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "bundled": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "requires": {
             "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+          "bundled": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+          "bundled": true
         },
         "osenv": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "bundled": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -6635,18 +6910,15 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+          "bundled": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+          "bundled": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+          "bundled": true
         },
         "protobufjs": {
           "version": "5.0.2",
@@ -6655,42 +6927,37 @@
           "requires": {
             "ascli": "1.0.1",
             "bytebuffer": "5.0.1",
-            "glob": "7.1.1",
+            "glob": "7.1.2",
             "yargs": "3.32.0"
           }
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "bundled": true
         },
         "qs": {
           "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+          "bundled": true
         },
         "rc": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-          "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+          "version": "1.2.4",
+          "bundled": true,
           "requires": {
             "deep-extend": "0.4.2",
-            "ini": "1.3.4",
+            "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "bundled": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "bundled": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -6703,8 +6970,7 @@
         },
         "request": {
           "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "bundled": true,
           "requires": {
             "aws-sign2": "0.6.0",
             "aws4": "1.6.0",
@@ -6727,49 +6993,42 @@
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.3",
             "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "uuid": "3.2.1"
           }
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "bundled": true,
           "requires": {
-            "glob": "7.1.1"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+          "bundled": true
         },
         "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+          "version": "5.5.0",
+          "bundled": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+          "bundled": true
         },
         "sntp": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "bundled": true,
           "requires": {
             "hoek": "2.16.3"
           }
         },
         "sshpk": {
           "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-          "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+          "bundled": true,
           "requires": {
             "asn1": "0.2.3",
             "assert-plus": "1.0.0",
@@ -6783,15 +7042,13 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+              "bundled": true
             }
           }
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -6800,34 +7057,29 @@
         },
         "string_decoder": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "bundled": true,
           "requires": {
             "safe-buffer": "5.1.1"
           }
         },
         "stringstream": {
           "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+          "bundled": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+          "bundled": true
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "requires": {
             "block-stream": "0.0.9",
             "fstream": "1.0.11",
@@ -6836,10 +7088,9 @@
         },
         "tar-pack": {
           "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
-          "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
+          "bundled": true,
           "requires": {
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "fstream": "1.0.11",
             "fstream-ignore": "1.0.5",
             "once": "1.4.0",
@@ -6851,45 +7102,38 @@
         },
         "tough-cookie": {
           "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "bundled": true,
           "requires": {
             "punycode": "1.4.1"
           }
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "bundled": true,
           "requires": {
             "safe-buffer": "5.1.1"
           }
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "bundled": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
+          "bundled": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+          "bundled": true
         },
         "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+          "version": "3.2.1",
+          "bundled": true
         },
         "verror": {
           "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+          "bundled": true,
           "requires": {
             "assert-plus": "1.0.0",
             "core-util-is": "1.0.2",
@@ -6898,35 +7142,32 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+              "bundled": true
             }
           }
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "requires": {
             "string-width": "1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "bundled": true
         }
       }
     },
     "gtoken": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.2.0.tgz",
-      "integrity": "sha512-tvQs8B1z5+I1FzMPZnq/OCuxTWFOkvy7cUJcpNdBOK2L7yEtPZTVCPtZU181sSDF+isUPebSqFTNTkIejFASAQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
+      "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
       "requires": {
         "axios": "0.18.0",
         "google-p12-pem": "1.0.2",
         "jws": "3.1.4",
-        "mime": "2.2.0",
+        "mime": "2.2.2",
         "pify": "3.0.0"
       }
     },
@@ -7009,6 +7250,35 @@
         "has-symbol-support-x": "1.4.2"
       }
     },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
     "has-yarn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
@@ -7064,7 +7334,7 @@
         "domutils": "1.7.0",
         "entities": "1.1.1",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.5"
+        "readable-stream": "2.3.6"
       }
     },
     "http-cache-semantics": {
@@ -7181,7 +7451,7 @@
       "integrity": "sha512-STx5orGQU1gfrkoI/fMU7lX6CSP7LBGO10gXNgOZhwKhUqbtNjCkYSewJtNnLmWP1tAGN6oyEpG1HFPw5vpa5Q==",
       "dev": true,
       "requires": {
-        "moment": "2.21.0",
+        "moment": "2.22.0",
         "sanitize-html": "1.18.2"
       }
     },
@@ -7191,11 +7461,11 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.0.0",
+        "ansi-escapes": "3.1.0",
         "chalk": "2.3.2",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.1.0",
+        "external-editor": "2.2.0",
         "figures": "2.0.0",
         "lodash": "4.17.5",
         "mute-stream": "0.0.7",
@@ -7285,6 +7555,14 @@
       "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
       "dev": true
     },
+    "is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "requires": {
+        "kind-of": "6.0.2"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -7323,6 +7601,24 @@
         "ci-info": "1.1.3"
       }
     },
+    "is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "requires": {
+        "kind-of": "6.0.2"
+      }
+    },
+    "is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "requires": {
+        "is-accessor-descriptor": "1.0.0",
+        "is-data-descriptor": "1.0.0",
+        "kind-of": "6.0.2"
+      }
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -7347,14 +7643,12 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -7380,12 +7674,11 @@
       "dev": true
     },
     "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "2.1.1"
       }
     },
     "is-installed-globally": {
@@ -7405,12 +7698,21 @@
       "dev": true
     },
     "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
         "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "is-obj": {
@@ -7434,6 +7736,21 @@
         "symbol-observable": "1.2.0"
       }
     },
+    "is-odd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+      "requires": {
+        "is-number": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+        }
+      }
+    },
     "is-path-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -7441,9 +7758,9 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
         "is-path-inside": "1.0.1"
@@ -7463,6 +7780,14 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "3.0.1"
+      }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -7507,9 +7832,9 @@
       "dev": true
     },
     "is-stream-ended": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.3.tgz",
-      "integrity": "sha1-oEc7Jnx1ZjVIa+7cfjNE5UnRUqw="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -7517,9 +7842,9 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-url": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.3.tgz",
-      "integrity": "sha512-vmOHLvzbcnsdFz8wQPXj1lgI5SE8AUlUGMenzuZzRFjoReb1WB+pLt9GrIo7BTker+aTcwrjTDle7odioWeqyw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true
     },
     "is-utf8": {
@@ -7527,6 +7852,11 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -7540,13 +7870,9 @@
       "dev": true
     },
     "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
-      "requires": {
-        "isarray": "1.0.0"
-      }
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
@@ -7618,7 +7944,7 @@
         "escape-string-regexp": "1.0.5",
         "js2xmlparser": "3.0.0",
         "klaw": "2.0.0",
-        "marked": "0.3.17",
+        "marked": "0.3.19",
         "mkdirp": "0.5.1",
         "requizzle": "0.2.1",
         "strip-json-comments": "2.0.1",
@@ -7647,9 +7973,9 @@
       "dev": true
     },
     "json-parse-better-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
     "json-schema": {
@@ -7757,13 +8083,9 @@
       }
     },
     "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
     },
     "klaw": {
       "version": "2.0.0",
@@ -8050,9 +8372,9 @@
       }
     },
     "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
     "lru-cache": {
@@ -8073,16 +8395,29 @@
         "pify": "3.0.0"
       }
     },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+    },
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "requires": {
+        "object-visit": "1.0.1"
+      }
+    },
     "marked": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.17.tgz",
-      "integrity": "sha512-+AKbNsjZl6jFfLPwHhWmGTqE009wTKn3RTmn9K8oUKHrX/abPJjtcRtXpYB/FFrwPJRUA86LX/de3T0knkPCmQ==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },
     "matcher": {
@@ -8253,6 +8588,11 @@
         "estraverse": "4.2.0"
       }
     },
+    "merge2": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.1.tgz",
+      "integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg=="
+    },
     "methmeth": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/methmeth/-/methmeth-1.1.0.tgz",
@@ -8266,30 +8606,29 @@
       "dev": true
     },
     "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.1",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.9",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "mime": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.2.0.tgz",
-      "integrity": "sha512-0Qz9uF1ATtl8RKJG4VRfOymh7PyEor6NbrI/61lRfuRe4vx9SNATrvAeTj2EWVRKjEQGskrzWkJBBY5NbaVHIA=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.2.2.tgz",
+      "integrity": "sha512-A7PDg4s48MkqFEcYg2b069m3DXOEq7hx+9q9rIFrSSYfzsh35GX+LOVMQ8Au0ko7d8bSQCIAuzkjp0vCtwENlQ=="
     },
     "mime-db": {
       "version": "1.33.0",
@@ -8329,6 +8668,25 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -8418,9 +8776,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.0.tgz",
+      "integrity": "sha512-1muXCh8jb1N/gHRbn9VDUBr0GYb8A/aVcHlII9QSB68a50spqEVLIGN6KVmCOnSvJrUhC0edGgKU5ofnGXdYdg==",
       "dev": true
     },
     "ms": {
@@ -8471,6 +8829,25 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
+    "nanomatch": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      }
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -8497,9 +8874,9 @@
       }
     },
     "node-forge": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.4.tgz",
-      "integrity": "sha512-8Df0906+tq/omxuCZD6PqhPaQDYuyJ1d+VITgxoIA8zvQd1ru+nMJcDChHH324MWitIgbVkAkQoGEEVJNpn/PA=="
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+      "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -8592,8 +8969,7 @@
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "3.2.2",
@@ -8603,26 +8979,22 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+          "bundled": true,
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "bundled": true,
           "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "default-require-extensions": "1.0.0"
@@ -8630,14 +9002,12 @@
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "bundled": true,
           "dev": true
         },
         "arr-diff": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-flatten": "1.1.0"
@@ -8645,50 +9015,42 @@
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+          "bundled": true,
           "dev": true
         },
         "arr-union": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+          "bundled": true,
           "dev": true
         },
         "array-unique": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "bundled": true,
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "bundled": true,
           "dev": true
         },
         "assign-symbols": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+          "bundled": true,
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "bundled": true,
           "dev": true
         },
         "atob": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
-          "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
+          "bundled": true,
           "dev": true
         },
         "babel-code-frame": {
           "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -8698,8 +9060,7 @@
         },
         "babel-generator": {
           "version": "6.26.1",
-          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-          "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-messages": "6.23.0",
@@ -8714,8 +9075,7 @@
         },
         "babel-messages": {
           "version": "6.23.0",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-runtime": "6.26.0"
@@ -8723,8 +9083,7 @@
         },
         "babel-runtime": {
           "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "core-js": "2.5.3",
@@ -8733,8 +9092,7 @@
         },
         "babel-template": {
           "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
@@ -8746,8 +9104,7 @@
         },
         "babel-traverse": {
           "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
@@ -8763,8 +9120,7 @@
         },
         "babel-types": {
           "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
@@ -8775,20 +9131,17 @@
         },
         "babylon": {
           "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "bundled": true,
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "bundled": true,
           "dev": true
         },
         "base": {
           "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-          "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cache-base": "1.0.1",
@@ -8802,8 +9155,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "1.0.2"
@@ -8811,16 +9163,14 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "1.0.0",
@@ -8829,8 +9179,7 @@
         },
         "braces": {
           "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "expand-range": "1.8.2",
@@ -8840,14 +9189,12 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "bundled": true,
           "dev": true
         },
         "cache-base": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-          "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "collection-visit": "1.0.0",
@@ -8863,16 +9210,14 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "caching-transform": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "md5-hex": "1.3.0",
@@ -8882,15 +9227,13 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -8900,8 +9243,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-styles": "2.2.1",
@@ -8913,8 +9255,7 @@
         },
         "class-utils": {
           "version": "0.3.6",
-          "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-          "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-union": "3.1.0",
@@ -8925,8 +9266,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
@@ -8934,8 +9274,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -8943,8 +9282,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
@@ -8954,8 +9292,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -8963,8 +9300,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
@@ -8974,8 +9310,7 @@
             },
             "is-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "0.1.6",
@@ -8985,22 +9320,19 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             },
             "kind-of": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "cliui": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9011,8 +9343,7 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -9020,14 +9351,12 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "collection-visit": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "map-visit": "1.0.0",
@@ -9036,44 +9365,37 @@
         },
         "commondir": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+          "bundled": true,
           "dev": true
         },
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "bundled": true,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+          "bundled": true,
           "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+          "bundled": true,
           "dev": true
         },
         "core-js": {
           "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+          "bundled": true,
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lru-cache": "4.1.2",
@@ -9082,8 +9404,7 @@
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -9091,26 +9412,22 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+          "bundled": true,
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "bundled": true,
           "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+          "bundled": true,
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "strip-bom": "2.0.0"
@@ -9118,8 +9435,7 @@
         },
         "define-property": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-descriptor": "1.0.2",
@@ -9128,16 +9444,14 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "detect-indent": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "repeating": "2.0.1"
@@ -9145,8 +9459,7 @@
         },
         "error-ex": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-arrayish": "0.2.1"
@@ -9154,20 +9467,17 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "bundled": true,
           "dev": true
         },
         "esutils": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "bundled": true,
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn": "5.1.0",
@@ -9181,8 +9491,7 @@
           "dependencies": {
             "cross-spawn": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lru-cache": "4.1.2",
@@ -9194,8 +9503,7 @@
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-posix-bracket": "0.1.1"
@@ -9203,8 +9511,7 @@
         },
         "expand-range": {
           "version": "1.8.2",
-          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fill-range": "2.2.3"
@@ -9212,8 +9519,7 @@
         },
         "extend-shallow": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "assign-symbols": "1.0.0",
@@ -9222,8 +9528,7 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-plain-object": "2.0.4"
@@ -9233,8 +9538,7 @@
         },
         "extglob": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-extglob": "1.0.0"
@@ -9242,14 +9546,12 @@
         },
         "filename-regex": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+          "bundled": true,
           "dev": true
         },
         "fill-range": {
           "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-number": "2.1.0",
@@ -9261,8 +9563,7 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "commondir": "1.0.1",
@@ -9272,8 +9573,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "locate-path": "2.0.0"
@@ -9281,14 +9581,12 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+          "bundled": true,
           "dev": true
         },
         "for-own": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "for-in": "1.0.2"
@@ -9296,8 +9594,7 @@
         },
         "foreground-child": {
           "version": "1.5.6",
-          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn": "4.0.2",
@@ -9306,8 +9603,7 @@
         },
         "fragment-cache": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-          "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "map-cache": "0.2.2"
@@ -9315,32 +9611,27 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "bundled": true,
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "bundled": true,
           "dev": true
         },
         "get-value": {
           "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+          "bundled": true,
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -9353,8 +9644,7 @@
         },
         "glob-base": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob-parent": "2.0.0",
@@ -9363,8 +9653,7 @@
         },
         "glob-parent": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-glob": "2.0.1"
@@ -9372,20 +9661,17 @@
         },
         "globals": {
           "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "bundled": true,
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "bundled": true,
           "dev": true
         },
         "handlebars": {
           "version": "4.0.11",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "async": "1.5.2",
@@ -9396,8 +9682,7 @@
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "amdefine": "1.0.1"
@@ -9407,8 +9692,7 @@
         },
         "has-ansi": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -9416,14 +9700,12 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "bundled": true,
           "dev": true
         },
         "has-value": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "get-value": "2.0.6",
@@ -9433,16 +9715,14 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "has-values": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-number": "3.0.0",
@@ -9451,8 +9731,7 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -9460,8 +9739,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
@@ -9471,8 +9749,7 @@
             },
             "kind-of": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-buffer": "1.1.6"
@@ -9482,20 +9759,17 @@
         },
         "hosted-git-info": {
           "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-          "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+          "bundled": true,
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -9504,14 +9778,12 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
         },
         "invariant": {
           "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
-          "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "loose-envify": "1.3.1"
@@ -9519,14 +9791,12 @@
         },
         "invert-kv": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "bundled": true,
           "dev": true
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "6.0.2"
@@ -9534,28 +9804,24 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "bundled": true,
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "bundled": true,
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "builtin-modules": "1.1.1"
@@ -9563,8 +9829,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "6.0.2"
@@ -9572,16 +9837,14 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "1.0.0",
@@ -9591,22 +9854,19 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "is-dotfile": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-          "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+          "bundled": true,
           "dev": true
         },
         "is-equal-shallow": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-primitive": "2.0.0"
@@ -9614,20 +9874,17 @@
         },
         "is-extendable": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+          "bundled": true,
           "dev": true
         },
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "bundled": true,
           "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -9635,14 +9892,12 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "bundled": true,
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-extglob": "1.0.0"
@@ -9650,8 +9905,7 @@
         },
         "is-number": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "3.2.2"
@@ -9659,8 +9913,7 @@
         },
         "is-odd": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-          "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-number": "4.0.0"
@@ -9668,16 +9921,14 @@
           "dependencies": {
             "is-number": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-              "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "is-plain-object": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isobject": "3.0.1"
@@ -9685,58 +9936,49 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "is-posix-bracket": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+          "bundled": true,
           "dev": true
         },
         "is-primitive": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+          "bundled": true,
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "bundled": true,
           "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+          "bundled": true,
           "dev": true
         },
         "is-windows": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+          "bundled": true,
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "bundled": true,
           "dev": true
         },
         "isobject": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isarray": "1.0.0"
@@ -9744,14 +9986,12 @@
         },
         "istanbul-lib-coverage": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-          "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
+          "bundled": true,
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
-          "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "append-transform": "0.4.0"
@@ -9759,8 +9999,7 @@
         },
         "istanbul-lib-instrument": {
           "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
-          "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-generator": "6.26.1",
@@ -9774,8 +10013,7 @@
         },
         "istanbul-lib-report": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
-          "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "istanbul-lib-coverage": "1.2.0",
@@ -9786,8 +10024,7 @@
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "has-flag": "1.0.0"
@@ -9797,8 +10034,7 @@
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
-          "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debug": "3.1.0",
@@ -9810,8 +10046,7 @@
           "dependencies": {
             "debug": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ms": "2.0.0"
@@ -9821,8 +10056,7 @@
         },
         "istanbul-reports": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
-          "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "handlebars": "4.0.11"
@@ -9830,20 +10064,17 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "bundled": true,
           "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "bundled": true,
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
@@ -9851,15 +10082,13 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "invert-kv": "1.0.0"
@@ -9867,8 +10096,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -9880,8 +10108,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-locate": "2.0.0",
@@ -9890,28 +10117,24 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "lodash": {
           "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "bundled": true,
           "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+          "bundled": true,
           "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "js-tokens": "3.0.2"
@@ -9919,8 +10142,7 @@
         },
         "lru-cache": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -9929,14 +10151,12 @@
         },
         "map-cache": {
           "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+          "bundled": true,
           "dev": true
         },
         "map-visit": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-visit": "1.0.1"
@@ -9944,8 +10164,7 @@
         },
         "md5-hex": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "md5-o-matic": "0.1.1"
@@ -9953,14 +10172,12 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+          "bundled": true,
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mimic-fn": "1.2.0"
@@ -9968,8 +10185,7 @@
         },
         "merge-source-map": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-          "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "source-map": "0.6.1"
@@ -9977,16 +10193,14 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "micromatch": {
           "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-diff": "2.0.0",
@@ -10006,14 +10220,12 @@
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "bundled": true,
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
@@ -10021,14 +10233,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "mixin-deep": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-          "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "for-in": "1.0.2",
@@ -10037,8 +10247,7 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-plain-object": "2.0.4"
@@ -10048,8 +10257,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -10057,14 +10265,12 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "dev": true
         },
         "nanomatch": {
           "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-          "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-diff": "4.0.0",
@@ -10083,28 +10289,24 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+              "bundled": true,
               "dev": true
             },
             "array-unique": {
               "version": "0.3.2",
-              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+              "bundled": true,
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "2.6.0",
@@ -10115,8 +10317,7 @@
         },
         "normalize-path": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "remove-trailing-separator": "1.1.0"
@@ -10124,8 +10325,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "path-key": "2.0.1"
@@ -10133,20 +10333,17 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true
         },
         "object-copy": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-          "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "copy-descriptor": "0.1.1",
@@ -10156,8 +10353,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
@@ -10165,8 +10361,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -10174,8 +10369,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -10183,8 +10377,7 @@
             },
             "is-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "0.1.6",
@@ -10194,8 +10387,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "5.1.0",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -10204,8 +10396,7 @@
         },
         "object-visit": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isobject": "3.0.1"
@@ -10213,16 +10404,14 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "object.omit": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "for-own": "0.1.5",
@@ -10231,8 +10420,7 @@
         },
         "object.pick": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-          "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isobject": "3.0.1"
@@ -10240,16 +10428,14 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -10257,8 +10443,7 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8",
@@ -10267,14 +10452,12 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "execa": "0.7.0",
@@ -10284,14 +10467,12 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+          "bundled": true,
           "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-try": "1.0.0"
@@ -10299,8 +10480,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-limit": "1.2.0"
@@ -10308,14 +10488,12 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "bundled": true,
           "dev": true
         },
         "parse-glob": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob-base": "0.3.0",
@@ -10326,8 +10504,7 @@
         },
         "parse-json": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "error-ex": "1.3.1"
@@ -10335,14 +10512,12 @@
         },
         "pascalcase": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+          "bundled": true,
           "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pinkie-promise": "2.0.1"
@@ -10350,26 +10525,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "bundled": true,
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+          "bundled": true,
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -10379,20 +10550,17 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "bundled": true,
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "bundled": true,
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pinkie": "2.0.4"
@@ -10400,8 +10568,7 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "find-up": "1.1.2"
@@ -10409,8 +10576,7 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "path-exists": "2.1.0",
@@ -10421,26 +10587,22 @@
         },
         "posix-character-classes": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+          "bundled": true,
           "dev": true
         },
         "preserve": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+          "bundled": true,
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+          "bundled": true,
           "dev": true
         },
         "randomatic": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-          "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-number": "3.0.0",
@@ -10449,8 +10611,7 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -10458,8 +10619,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
@@ -10469,8 +10629,7 @@
             },
             "kind-of": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-buffer": "1.1.6"
@@ -10480,8 +10639,7 @@
         },
         "read-pkg": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "load-json-file": "1.1.0",
@@ -10491,8 +10649,7 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "find-up": "1.1.2",
@@ -10501,8 +10658,7 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "path-exists": "2.1.0",
@@ -10513,14 +10669,12 @@
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "bundled": true,
           "dev": true
         },
         "regex-cache": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-          "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-equal-shallow": "0.1.3"
@@ -10528,8 +10682,7 @@
         },
         "regex-not": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-          "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "extend-shallow": "3.0.2",
@@ -10538,26 +10691,22 @@
         },
         "remove-trailing-separator": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-          "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+          "bundled": true,
           "dev": true
         },
         "repeat-element": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+          "bundled": true,
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+          "bundled": true,
           "dev": true
         },
         "repeating": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-finite": "1.0.2"
@@ -10565,38 +10714,32 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "bundled": true,
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "bundled": true,
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "bundled": true,
           "dev": true
         },
         "resolve-url": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+          "bundled": true,
           "dev": true
         },
         "ret": {
           "version": "0.1.15",
-          "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+          "bundled": true,
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10605,8 +10748,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -10614,8 +10756,7 @@
         },
         "safe-regex": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-          "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ret": "0.1.15"
@@ -10623,20 +10764,17 @@
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "bundled": true,
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true
         },
         "set-value": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-          "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "extend-shallow": "2.0.1",
@@ -10647,8 +10785,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
@@ -10658,8 +10795,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "shebang-regex": "1.0.0"
@@ -10667,26 +10803,22 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "bundled": true,
           "dev": true
         },
         "snapdragon": {
           "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-          "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "base": "0.11.2",
@@ -10701,8 +10833,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
@@ -10710,8 +10841,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
@@ -10719,8 +10849,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -10728,8 +10857,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
@@ -10739,8 +10867,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -10748,8 +10875,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
@@ -10759,8 +10885,7 @@
             },
             "is-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "0.1.6",
@@ -10770,16 +10895,14 @@
             },
             "kind-of": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "snapdragon-node": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-          "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "define-property": "1.0.0",
@@ -10789,8 +10912,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "1.0.2"
@@ -10798,16 +10920,14 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "snapdragon-util": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-          "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "3.2.2"
@@ -10815,14 +10935,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "bundled": true,
           "dev": true
         },
         "source-map-resolve": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-          "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "atob": "2.0.3",
@@ -10834,14 +10952,12 @@
         },
         "source-map-url": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+          "bundled": true,
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
-          "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "foreground-child": "1.5.6",
@@ -10854,8 +10970,7 @@
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-expression-parse": "3.0.0",
@@ -10864,14 +10979,12 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+          "bundled": true,
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-exceptions": "2.1.0",
@@ -10880,14 +10993,12 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+          "bundled": true,
           "dev": true
         },
         "split-string": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-          "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "extend-shallow": "3.0.2"
@@ -10895,8 +11006,7 @@
         },
         "static-extend": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-          "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "define-property": "0.2.5",
@@ -10905,8 +11015,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
@@ -10914,8 +11023,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -10923,8 +11031,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
@@ -10934,8 +11041,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -10943,8 +11049,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
@@ -10954,8 +11059,7 @@
             },
             "is-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "0.1.6",
@@ -10965,16 +11069,14 @@
             },
             "kind-of": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -10983,14 +11085,12 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "bundled": true,
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
@@ -11000,8 +11100,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -11009,8 +11108,7 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-utf8": "0.2.1"
@@ -11018,20 +11116,17 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+          "bundled": true,
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "bundled": true,
           "dev": true
         },
         "test-exclude": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
-          "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arrify": "1.0.1",
@@ -11043,20 +11138,17 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+              "bundled": true,
               "dev": true
             },
             "array-unique": {
               "version": "0.3.2",
-              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+              "bundled": true,
               "dev": true
             },
             "braces": {
               "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
-              "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "arr-flatten": "1.1.0",
@@ -11075,8 +11167,7 @@
               "dependencies": {
                 "define-property": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-                  "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-descriptor": "1.0.2"
@@ -11084,8 +11175,7 @@
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-extendable": "0.1.1"
@@ -11095,8 +11185,7 @@
             },
             "expand-brackets": {
               "version": "2.1.4",
-              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-              "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "debug": "2.6.9",
@@ -11110,8 +11199,7 @@
               "dependencies": {
                 "define-property": {
                   "version": "0.2.5",
-                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                  "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-descriptor": "0.1.6"
@@ -11119,8 +11207,7 @@
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-extendable": "0.1.1"
@@ -11128,8 +11215,7 @@
                 },
                 "is-descriptor": {
                   "version": "0.1.6",
-                  "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                  "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-accessor-descriptor": "0.1.6",
@@ -11139,16 +11225,14 @@
                 },
                 "kind-of": {
                   "version": "5.1.0",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "extglob": {
               "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-              "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "array-unique": "0.3.2",
@@ -11163,8 +11247,7 @@
               "dependencies": {
                 "define-property": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-                  "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-descriptor": "1.0.2"
@@ -11172,8 +11255,7 @@
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-extendable": "0.1.1"
@@ -11183,8 +11265,7 @@
             },
             "fill-range": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "extend-shallow": "2.0.1",
@@ -11195,8 +11276,7 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-extendable": "0.1.1"
@@ -11206,8 +11286,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -11215,8 +11294,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
@@ -11226,8 +11304,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -11235,8 +11312,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
@@ -11246,8 +11322,7 @@
             },
             "is-number": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -11255,8 +11330,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
@@ -11266,20 +11340,17 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "bundled": true,
               "dev": true
             },
             "micromatch": {
               "version": "3.1.9",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
-              "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "arr-diff": "4.0.0",
@@ -11301,14 +11372,12 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "bundled": true,
           "dev": true
         },
         "to-object-path": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-          "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "3.2.2"
@@ -11316,8 +11385,7 @@
         },
         "to-regex": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-          "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "define-property": "2.0.2",
@@ -11328,8 +11396,7 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-number": "3.0.0",
@@ -11338,8 +11405,7 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -11349,14 +11415,12 @@
         },
         "trim-right": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+          "bundled": true,
           "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -11367,8 +11431,7 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -11382,15 +11445,13 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "union-value": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-union": "3.1.0",
@@ -11401,8 +11462,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
@@ -11410,8 +11470,7 @@
             },
             "set-value": {
               "version": "0.4.3",
-              "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-              "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "extend-shallow": "2.0.1",
@@ -11424,8 +11483,7 @@
         },
         "unset-value": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "has-value": "0.3.1",
@@ -11434,8 +11492,7 @@
           "dependencies": {
             "has-value": {
               "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "get-value": "2.0.6",
@@ -11445,8 +11502,7 @@
               "dependencies": {
                 "isobject": {
                   "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "isarray": "1.0.0"
@@ -11456,28 +11512,24 @@
             },
             "has-values": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+              "bundled": true,
               "dev": true
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "urix": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+          "bundled": true,
           "dev": true
         },
         "use": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-          "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "6.0.2"
@@ -11485,16 +11537,14 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "validate-npm-package-license": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-          "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-correct": "3.0.0",
@@ -11503,8 +11553,7 @@
         },
         "which": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isexe": "2.0.0"
@@ -11512,27 +11561,23 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "bundled": true,
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "bundled": true,
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "1.0.2",
@@ -11541,8 +11586,7 @@
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "number-is-nan": "1.0.1"
@@ -11550,8 +11594,7 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
@@ -11563,14 +11606,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -11580,20 +11621,17 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "bundled": true,
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "bundled": true,
           "dev": true
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cliui": "4.0.0",
@@ -11612,20 +11650,17 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "bundled": true,
               "dev": true
             },
             "camelcase": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "bundled": true,
               "dev": true
             },
             "cliui": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-              "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "string-width": "2.1.1",
@@ -11635,8 +11670,7 @@
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
@@ -11644,8 +11678,7 @@
             },
             "yargs-parser": {
               "version": "9.0.2",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-              "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "camelcase": "4.1.0"
@@ -11655,8 +11688,7 @@
         },
         "yargs-parser": {
           "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "camelcase": "4.1.0"
@@ -11664,8 +11696,7 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "bundled": true,
               "dev": true
             }
           }
@@ -11683,10 +11714,79 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+            }
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "requires": {
+        "isobject": "3.0.1"
+      }
     },
     "object.omit": {
       "version": "2.0.1",
@@ -11696,6 +11796,14 @@
       "requires": {
         "for-own": "0.1.5",
         "is-extendable": "0.1.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "requires": {
+        "isobject": "3.0.1"
       }
     },
     "observable-to-promise": {
@@ -11894,7 +12002,7 @@
             "is-redirect": "1.0.0",
             "is-retry-allowed": "1.1.0",
             "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.0",
+            "lowercase-keys": "1.0.1",
             "safe-buffer": "5.1.1",
             "timed-out": "4.0.1",
             "unzip-response": "2.0.1",
@@ -11913,6 +12021,23 @@
         "is-dotfile": "1.0.3",
         "is-extglob": "1.0.0",
         "is-glob": "2.0.1"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
       }
     },
     "parse-json": {
@@ -11929,6 +12054,16 @@
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
       "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
       "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
     "path-exists": {
       "version": "3.0.0",
@@ -12038,7 +12173,7 @@
           "dev": true,
           "requires": {
             "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
+            "json-parse-better-errors": "1.0.2"
           }
         }
       }
@@ -12067,10 +12202,15 @@
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    },
     "postcss": {
-      "version": "6.0.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
-      "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
+      "version": "6.0.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+      "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.2",
@@ -12087,9 +12227,9 @@
       }
     },
     "power-assert": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.4.4.tgz",
-      "integrity": "sha1-kpXqdDcZb1pgH95CDwQmMRhtdRc=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.5.0.tgz",
+      "integrity": "sha512-WaWSw+Ts283o6dzxW1BxIxoaHok7aSSGx4SaR6dW62Pk31ynv9DERDieuZpPYv5XaJ+H+zdcOaJQ+PvlasAOVw==",
       "requires": {
         "define-properties": "1.1.2",
         "empower": "1.2.3",
@@ -12103,7 +12243,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz",
       "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "power-assert-context-traversal": "1.1.1"
       }
     },
@@ -12114,7 +12254,7 @@
       "requires": {
         "acorn": "4.0.13",
         "acorn-es7-plugin": "1.1.7",
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
       }
@@ -12124,7 +12264,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.1.1.tgz",
       "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "estraverse": "4.2.0"
       }
     },
@@ -12133,7 +12273,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-formatter/-/power-assert-formatter-1.4.1.tgz",
       "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "power-assert-context-formatter": "1.1.1",
         "power-assert-context-reducer-ast": "1.1.2",
         "power-assert-renderer-assertion": "1.1.1",
@@ -12161,7 +12301,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.1.1.tgz",
       "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "diff-match-patch": "1.0.0",
         "power-assert-renderer-base": "1.1.1",
         "stringifier": "1.3.0",
@@ -12173,7 +12313,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.1.2.tgz",
       "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "power-assert-renderer-base": "1.1.1",
         "power-assert-util-string-width": "1.1.1",
         "stringifier": "1.3.0"
@@ -12216,7 +12356,8 @@
     "prettier": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.11.1.tgz",
-      "integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw=="
+      "integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw==",
+      "dev": true
     },
     "pretty-ms": {
       "version": "3.1.0",
@@ -12269,7 +12410,7 @@
         "@protobufjs/pool": "1.1.0",
         "@protobufjs/utf8": "1.1.0",
         "@types/long": "3.0.32",
-        "@types/node": "8.9.5",
+        "@types/node": "8.10.3",
         "long": "4.0.0"
       }
     },
@@ -12320,26 +12461,6 @@
         "kind-of": "4.0.0"
       },
       "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -12410,16 +12531,16 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
         "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
+        "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
       }
     },
@@ -12431,7 +12552,7 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "set-immediate-shim": "1.0.1"
       }
     },
@@ -12477,10 +12598,19 @@
         "is-equal-shallow": "0.1.3"
       }
     },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "requires": {
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
     "regexpp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.0.1.tgz",
-      "integrity": "sha512-8Ph721maXiOYSLtaDGKVmDn5wdsNaF6Px85qFNeMPQq0r8K5Y10tgP6YuR65Ws35n4DvzFcCxEnRNBIXQunzLw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
       "dev": true
     },
     "regexpu-core": {
@@ -12546,14 +12676,12 @@
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
@@ -12667,13 +12795,18 @@
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
     "responselike": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
-        "lowercase-keys": "1.0.0"
+        "lowercase-keys": "1.0.1"
       }
     },
     "restore-cursor": {
@@ -12685,6 +12818,11 @@
         "onetime": "2.0.1",
         "signal-exit": "3.0.2"
       }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "retry-axios": {
       "version": "0.3.2",
@@ -12749,6 +12887,14 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "requires": {
+        "ret": "0.1.15"
+      }
+    },
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
@@ -12768,7 +12914,7 @@
         "lodash.isplainobject": "4.0.6",
         "lodash.isstring": "4.0.1",
         "lodash.mergewith": "4.6.1",
-        "postcss": "6.0.20",
+        "postcss": "6.0.21",
         "srcset": "1.0.0",
         "xtend": "4.0.1"
       }
@@ -12805,6 +12951,27 @@
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -12870,6 +13037,128 @@
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
     },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
@@ -12890,8 +13179,19 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "source-map-resolve": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "requires": {
+        "atob": "2.1.0",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
     },
     "source-map-support": {
       "version": "0.5.4",
@@ -12909,6 +13209,11 @@
           "dev": true
         }
       }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "spdx-correct": {
       "version": "3.0.0",
@@ -12949,7 +13254,15 @@
       "dev": true,
       "requires": {
         "async": "2.6.0",
-        "is-stream-ended": "0.1.3"
+        "is-stream-ended": "0.1.4"
+      }
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "requires": {
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -12989,10 +13302,80 @@
       "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
       "dev": true
     },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
+    },
     "stream-events": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.2.tgz",
-      "integrity": "sha1-q/OfZsCJCk63lbyNXoWbJhW1kLI=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.3.tgz",
+      "integrity": "sha512-SvnBCMhEBQSJml4/ImlWkzGWgchjo1tVxnoBUOa1i1g3BsYNWz4W6a9Hc8VhqfmwJiEGu6tLrGdNRm/K/I4YXw==",
       "dev": true,
       "requires": {
         "stubs": "3.0.0"
@@ -13001,8 +13384,7 @@
     "stream-shift": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -13033,9 +13415,9 @@
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -13045,7 +13427,7 @@
       "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
       "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "traverse": "0.6.6",
         "type-name": "2.0.2"
       }
@@ -13120,9 +13502,18 @@
         "methods": "1.1.2",
         "mime": "1.6.0",
         "qs": "6.5.1",
-        "readable-stream": "2.3.5"
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "mime": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -13279,7 +13670,7 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "xtend": "4.0.1"
       }
     },
@@ -13309,6 +13700,44 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "requires": {
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      }
     },
     "tough-cookie": {
       "version": "2.3.4",
@@ -13477,6 +13906,38 @@
         }
       }
     },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
@@ -13513,6 +13974,42 @@
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
       "dev": true
     },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+        }
+      }
+    },
     "unzip-response": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
@@ -13520,21 +14017,27 @@
       "dev": true
     },
     "update-notifier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz",
+      "integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
       "dev": true,
       "requires": {
         "boxen": "1.3.0",
         "chalk": "2.3.2",
-        "configstore": "3.1.1",
+        "configstore": "3.1.2",
         "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
         "is-installed-globally": "0.1.0",
         "is-npm": "1.0.0",
         "latest-version": "3.1.0",
         "semver-diff": "2.1.0",
         "xdg-basedir": "3.0.0"
       }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url-parse-lax": {
       "version": "1.0.0",
@@ -13556,6 +14059,14 @@
       "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
       "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
       "dev": true
+    },
+    "use": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+      "requires": {
+        "kind-of": "6.0.2"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test": "repo-tools test run --cmd npm -- run cover"
   },
   "dependencies": {
-    "google-gax": "^0.14.2",
+    "google-gax": "^0.16.0",
     "lodash.merge": "^4.6.0",
     "lodash.union": "^4.6.0",
     "protobufjs": "^6.8.0"

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -90,7 +90,7 @@
         "request": "2.85.0",
         "retry-request": "3.3.1",
         "split-array-stream": "1.0.3",
-        "stream-events": "1.0.2",
+        "stream-events": "1.0.3",
         "string-format-obj": "1.1.1",
         "through2": "2.0.3"
       }
@@ -495,7 +495,7 @@
         "clean-stack": "1.3.0",
         "clean-yaml-object": "0.1.0",
         "cli-cursor": "2.1.0",
-        "cli-spinners": "1.1.0",
+        "cli-spinners": "1.3.0",
         "cli-truncate": "1.1.0",
         "co-with-promise": "4.6.0",
         "code-excerpt": "2.1.1",
@@ -554,7 +554,7 @@
         "supports-color": "3.2.3",
         "time-require": "0.1.2",
         "unique-temp-dir": "1.0.0",
-        "update-notifier": "2.3.0"
+        "update-notifier": "2.4.0"
       }
     },
     "ava-init": {
@@ -829,7 +829,7 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "espower-location-detector": "1.0.0",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -970,7 +970,7 @@
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.5",
         "mkdirp": "0.5.1",
@@ -983,7 +983,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -1251,7 +1251,7 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "deep-equal": "1.0.1",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -1379,9 +1379,9 @@
       }
     },
     "cli-spinners": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
-      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.0.tgz",
+      "integrity": "sha512-ahr3q/EW26uLN3vqBaDQS4g1rUwKMbVSTRlyfyoY06VwwSJmMYRxhT3FTAiTz9Yam6OOb1e0ldwvbsnuThvuzA==",
       "dev": true
     },
     "cli-truncate": {
@@ -1545,14 +1545,14 @@
       "requires": {
         "buffer-from": "1.0.0",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
       }
     },
     "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
         "dot-prop": "4.2.0",
@@ -1592,9 +1592,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+      "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
       "dev": true
     },
     "core-util-is": {
@@ -1723,7 +1723,7 @@
     "dialogflow": {
       "version": "0.2.0",
       "requires": {
-        "google-gax": "0.14.5",
+        "google-gax": "0.16.0",
         "lodash.merge": "4.6.1",
         "lodash.union": "4.6.0",
         "protobufjs": "6.8.6"
@@ -1810,7 +1810,7 @@
             "request": "2.85.0",
             "retry-request": "3.3.1",
             "split-array-stream": "1.0.3",
-            "stream-events": "1.0.2",
+            "stream-events": "1.0.3",
             "string-format-obj": "1.1.1",
             "through2": "2.0.3"
           },
@@ -1847,7 +1847,7 @@
               "version": "0.1.2",
               "bundled": true,
               "requires": {
-                "node-forge": "0.7.4"
+                "node-forge": "0.7.5"
               }
             },
             "gtoken": {
@@ -1867,7 +1867,7 @@
           }
         },
         "@google-cloud/nodejs-repo-tools": {
-          "version": "2.2.4",
+          "version": "2.2.6",
           "bundled": true,
           "requires": {
             "ava": "0.25.0",
@@ -3367,6 +3367,14 @@
             }
           }
         },
+        "@mrmlnc/readdir-enhanced": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "call-me-maybe": "1.0.1",
+            "glob-to-regexp": "0.3.0"
+          }
+        },
         "@protobufjs/aspromise": {
           "version": "1.1.2",
           "bundled": true
@@ -3427,7 +3435,7 @@
           "bundled": true
         },
         "@types/node": {
-          "version": "8.9.5",
+          "version": "8.10.3",
           "bundled": true
         },
         "acorn": {
@@ -3472,6 +3480,15 @@
             "kind-of": "3.2.2",
             "longest": "1.0.1",
             "repeat-string": "1.6.1"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
           }
         },
         "amdefine": {
@@ -3511,7 +3528,7 @@
           }
         },
         "ansi-escapes": {
-          "version": "3.0.0",
+          "version": "3.1.0",
           "bundled": true
         },
         "ansi-regex": {
@@ -3531,6 +3548,79 @@
           "requires": {
             "micromatch": "2.3.11",
             "normalize-path": "2.1.1"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "1.1.0"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "0.1.1"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
+              }
+            }
           }
         },
         "argparse": {
@@ -3540,20 +3630,13 @@
             "sprintf-js": "1.0.3"
           }
         },
-        "arguejs": {
-          "version": "0.2.3",
-          "bundled": true
-        },
         "argv": {
           "version": "0.0.2",
           "bundled": true
         },
         "arr-diff": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "arr-flatten": "1.1.0"
-          }
+          "version": "4.0.0",
+          "bundled": true
         },
         "arr-exclude": {
           "version": "1.0.0",
@@ -3561,6 +3644,10 @@
         },
         "arr-flatten": {
           "version": "1.1.0",
+          "bundled": true
+        },
+        "arr-union": {
+          "version": "3.1.0",
           "bundled": true
         },
         "array-differ": {
@@ -3591,7 +3678,7 @@
           "bundled": true
         },
         "array-unique": {
-          "version": "0.2.1",
+          "version": "0.3.2",
           "bundled": true
         },
         "arrify": {
@@ -3614,6 +3701,10 @@
           "version": "1.0.0",
           "bundled": true
         },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
         "async": {
           "version": "2.6.0",
           "bundled": true,
@@ -3629,6 +3720,10 @@
           "version": "0.4.0",
           "bundled": true
         },
+        "atob": {
+          "version": "2.1.0",
+          "bundled": true
+        },
         "auto-bind": {
           "version": "1.2.0",
           "bundled": true
@@ -3642,7 +3737,7 @@
             "@ava/write-file-atomic": "2.2.0",
             "@concordance/react": "1.0.0",
             "@ladjs/time-require": "0.1.4",
-            "ansi-escapes": "3.0.0",
+            "ansi-escapes": "3.1.0",
             "ansi-styles": "3.2.1",
             "arr-flatten": "1.1.0",
             "array-union": "1.0.2",
@@ -3660,7 +3755,7 @@
             "clean-stack": "1.3.0",
             "clean-yaml-object": "0.1.0",
             "cli-cursor": "2.1.0",
-            "cli-spinners": "1.1.0",
+            "cli-spinners": "1.3.0",
             "cli-truncate": "1.1.0",
             "co-with-promise": "4.6.0",
             "code-excerpt": "2.1.1",
@@ -3719,12 +3814,19 @@
             "supports-color": "5.3.0",
             "trim-off-newlines": "1.0.1",
             "unique-temp-dir": "1.0.0",
-            "update-notifier": "2.3.0"
+            "update-notifier": "2.4.0"
           },
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
               "bundled": true
+            },
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
             },
             "globby": {
               "version": "6.1.0",
@@ -3841,15 +3943,6 @@
             "private": "0.1.8",
             "slash": "1.0.0",
             "source-map": "0.5.7"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
           }
         },
         "babel-generator": {
@@ -3976,7 +4069,7 @@
             "babel-generator": "6.26.1",
             "babylon": "6.18.0",
             "call-matcher": "1.0.1",
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "espower-location-detector": "1.0.0",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
@@ -4093,7 +4186,7 @@
           "requires": {
             "babel-core": "6.26.0",
             "babel-runtime": "6.26.0",
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "home-or-tmp": "2.0.0",
             "lodash": "4.17.5",
             "mkdirp": "0.5.1",
@@ -4113,7 +4206,7 @@
           "version": "6.26.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -4141,15 +4234,6 @@
             "globals": "9.18.0",
             "invariant": "2.2.4",
             "lodash": "4.17.5"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
           }
         },
         "babel-types": {
@@ -4169,6 +4253,28 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true
+        },
+        "base": {
+          "version": "0.11.2",
+          "bundled": true,
+          "requires": {
+            "cache-base": "1.0.1",
+            "class-utils": "0.3.6",
+            "component-emitter": "1.2.1",
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "mixin-deep": "1.3.1",
+            "pascalcase": "0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            }
+          }
         },
         "base64url": {
           "version": "2.0.0",
@@ -4248,12 +4354,37 @@
           }
         },
         "braces": {
-          "version": "1.8.5",
+          "version": "2.3.1",
           "bundled": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "kind-of": "6.0.2",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
           }
         },
         "browser-stdout": {
@@ -4289,6 +4420,21 @@
             }
           }
         },
+        "cache-base": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "collection-visit": "1.0.0",
+            "component-emitter": "1.2.1",
+            "get-value": "2.0.6",
+            "has-value": "1.0.0",
+            "isobject": "3.0.1",
+            "set-value": "2.0.0",
+            "to-object-path": "0.3.0",
+            "union-value": "1.0.0",
+            "unset-value": "1.0.0"
+          }
+        },
         "cacheable-request": {
           "version": "2.1.4",
           "bundled": true,
@@ -4300,6 +4446,12 @@
             "lowercase-keys": "1.0.0",
             "normalize-url": "2.0.1",
             "responselike": "1.0.2"
+          },
+          "dependencies": {
+            "lowercase-keys": {
+              "version": "1.0.0",
+              "bundled": true
+            }
           }
         },
         "caching-transform": {
@@ -4333,11 +4485,15 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "deep-equal": "1.0.1",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
           }
+        },
+        "call-me-maybe": {
+          "version": "1.0.1",
+          "bundled": true
         },
         "call-signature": {
           "version": "0.0.2",
@@ -4416,6 +4572,26 @@
             "is-glob": "2.0.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0"
+          },
+          "dependencies": {
+            "glob-parent": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-glob": "2.0.1"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            }
           }
         },
         "ci-info": {
@@ -4425,6 +4601,70 @@
         "circular-json": {
           "version": "0.3.3",
           "bundled": true
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "bundled": true,
+          "requires": {
+            "arr-union": "3.1.0",
+            "define-property": "0.2.5",
+            "isobject": "3.0.1",
+            "static-extend": "0.1.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
         },
         "clean-stack": {
           "version": "1.3.0",
@@ -4446,7 +4686,7 @@
           }
         },
         "cli-spinners": {
-          "version": "1.1.0",
+          "version": "1.3.0",
           "bundled": true
         },
         "cli-truncate": {
@@ -4652,6 +4892,14 @@
             }
           }
         },
+        "collection-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "map-visit": "1.0.0",
+            "object-visit": "1.0.1"
+          }
+        },
         "color-convert": {
           "version": "1.9.1",
           "bundled": true,
@@ -4707,7 +4955,7 @@
           "requires": {
             "buffer-from": "1.0.0",
             "inherits": "2.0.3",
-            "readable-stream": "2.3.5",
+            "readable-stream": "2.3.6",
             "typedarray": "0.0.6"
           }
         },
@@ -4738,7 +4986,7 @@
           }
         },
         "configstore": {
-          "version": "3.1.1",
+          "version": "3.1.2",
           "bundled": true,
           "requires": {
             "dot-prop": "4.2.0",
@@ -4761,6 +5009,10 @@
           "version": "2.1.1",
           "bundled": true
         },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "bundled": true
+        },
         "core-assert": {
           "version": "0.2.1",
           "bundled": true,
@@ -4770,7 +5022,7 @@
           }
         },
         "core-js": {
-          "version": "2.5.3",
+          "version": "2.5.4",
           "bundled": true
         },
         "core-util-is": {
@@ -4824,7 +5076,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "es5-ext": "0.10.41"
+            "es5-ext": "0.10.42"
           }
         },
         "dashdash": {
@@ -4839,7 +5091,7 @@
           "bundled": true
         },
         "debug": {
-          "version": "3.1.0",
+          "version": "2.6.9",
           "bundled": true,
           "requires": {
             "ms": "2.0.0"
@@ -4880,13 +5132,21 @@
             "object-keys": "1.0.11"
           }
         },
+        "define-property": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "is-descriptor": "1.0.2",
+            "isobject": "3.0.1"
+          }
+        },
         "del": {
           "version": "2.2.2",
           "bundled": true,
           "requires": {
             "globby": "5.0.0",
             "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.1",
             "object-assign": "4.1.1",
             "pify": "2.3.0",
             "pinkie-promise": "2.0.1",
@@ -5006,7 +5266,7 @@
           "requires": {
             "end-of-stream": "1.4.1",
             "inherits": "2.0.3",
-            "readable-stream": "2.3.5",
+            "readable-stream": "2.3.6",
             "stream-shift": "1.0.0"
           }
         },
@@ -5034,7 +5294,7 @@
           "version": "1.2.3",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "empower-core": "0.6.2"
           }
         },
@@ -5050,7 +5310,7 @@
           "bundled": true,
           "requires": {
             "call-signature": "0.0.2",
-            "core-js": "2.5.3"
+            "core-js": "2.5.4"
           }
         },
         "end-of-stream": {
@@ -5080,7 +5340,7 @@
           }
         },
         "es5-ext": {
-          "version": "0.10.41",
+          "version": "0.10.42",
           "bundled": true,
           "requires": {
             "es6-iterator": "2.0.3",
@@ -5097,7 +5357,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.41",
+            "es5-ext": "0.10.42",
             "es6-symbol": "3.1.1"
           }
         },
@@ -5106,7 +5366,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.41",
+            "es5-ext": "0.10.42",
             "es6-iterator": "2.0.3",
             "es6-set": "0.1.5",
             "es6-symbol": "3.1.1",
@@ -5118,7 +5378,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.41",
+            "es5-ext": "0.10.42",
             "es6-iterator": "2.0.3",
             "es6-symbol": "3.1.1",
             "event-emitter": "0.3.5"
@@ -5129,7 +5389,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.41"
+            "es5-ext": "0.10.42"
           }
         },
         "es6-weak-map": {
@@ -5137,7 +5397,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.41",
+            "es5-ext": "0.10.42",
             "es6-iterator": "2.0.3",
             "es6-symbol": "3.1.1"
           }
@@ -5193,7 +5453,7 @@
           }
         },
         "eslint": {
-          "version": "4.19.0",
+          "version": "4.19.1",
           "bundled": true,
           "requires": {
             "ajv": "5.5.2",
@@ -5206,12 +5466,12 @@
             "eslint-scope": "3.7.1",
             "eslint-visitor-keys": "1.0.0",
             "espree": "3.5.4",
-            "esquery": "1.0.0",
+            "esquery": "1.0.1",
             "esutils": "2.0.2",
             "file-entry-cache": "2.0.0",
             "functional-red-black-tree": "1.0.1",
             "glob": "7.1.2",
-            "globals": "11.3.0",
+            "globals": "11.4.0",
             "ignore": "3.3.7",
             "imurmurhash": "0.1.4",
             "inquirer": "3.3.0",
@@ -5227,7 +5487,7 @@
             "path-is-inside": "1.0.2",
             "pluralize": "7.0.0",
             "progress": "2.0.0",
-            "regexpp": "1.0.1",
+            "regexpp": "1.1.0",
             "require-uncached": "1.0.3",
             "semver": "5.5.0",
             "strip-ansi": "4.0.0",
@@ -5240,8 +5500,15 @@
               "version": "3.0.0",
               "bundled": true
             },
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
             "globals": {
-              "version": "11.3.0",
+              "version": "11.4.0",
               "bundled": true
             },
             "strip-ansi": {
@@ -5349,7 +5616,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "is-url": "1.2.3",
+            "is-url": "1.2.4",
             "path-is-absolute": "1.0.1",
             "source-map": "0.5.7",
             "xtend": "4.0.1"
@@ -5400,11 +5667,11 @@
           "version": "1.7.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3"
+            "core-js": "2.5.4"
           }
         },
         "esquery": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true,
           "requires": {
             "estraverse": "4.2.0"
@@ -5430,7 +5697,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.41"
+            "es5-ext": "0.10.42"
           }
         },
         "execa": {
@@ -5447,10 +5714,77 @@
           }
         },
         "expand-brackets": {
-          "version": "0.1.5",
+          "version": "2.1.4",
           "bundled": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
           }
         },
         "expand-range": {
@@ -5458,14 +5792,65 @@
           "bundled": true,
           "requires": {
             "fill-range": "2.2.3"
+          },
+          "dependencies": {
+            "fill-range": {
+              "version": "2.2.3",
+              "bundled": true,
+              "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.7",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+              }
+            },
+            "is-number": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "isobject": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
           }
         },
         "extend": {
           "version": "3.0.1",
           "bundled": true
         },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "2.0.4"
+              }
+            }
+          }
+        },
         "external-editor": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "bundled": true,
           "requires": {
             "chardet": "0.4.2",
@@ -5474,10 +5859,33 @@
           }
         },
         "extglob": {
-          "version": "0.3.2",
+          "version": "2.0.4",
           "bundled": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
           }
         },
         "extsprintf": {
@@ -5491,6 +5899,17 @@
         "fast-diff": {
           "version": "1.1.2",
           "bundled": true
+        },
+        "fast-glob": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "2.2.1",
+            "glob-parent": "3.1.0",
+            "is-glob": "4.0.0",
+            "merge2": "1.2.1",
+            "micromatch": "3.1.10"
+          }
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
@@ -5528,14 +5947,22 @@
           }
         },
         "fill-range": {
-          "version": "2.2.3",
+          "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
           }
         },
         "find-cache-dir": {
@@ -5573,6 +6000,15 @@
           "bundled": true,
           "requires": {
             "debug": "3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
           }
         },
         "for-in": {
@@ -5607,12 +6043,19 @@
           "version": "1.2.1",
           "bundled": true
         },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "map-cache": "0.2.2"
+          }
+        },
         "from2": {
           "version": "2.3.0",
           "bundled": true,
           "requires": {
             "inherits": "2.0.3",
-            "readable-stream": "2.3.5"
+            "readable-stream": "2.3.6"
           }
         },
         "fs-extra": {
@@ -5661,6 +6104,10 @@
           "version": "3.0.0",
           "bundled": true
         },
+        "get-value": {
+          "version": "2.0.6",
+          "bundled": true
+        },
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
@@ -5686,14 +6133,48 @@
           "requires": {
             "glob-parent": "2.0.0",
             "is-glob": "2.0.1"
+          },
+          "dependencies": {
+            "glob-parent": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-glob": "2.0.1"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            }
           }
         },
         "glob-parent": {
-          "version": "2.0.0",
+          "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "2.1.1"
+              }
+            }
           }
+        },
+        "glob-to-regexp": {
+          "version": "0.3.0",
+          "bundled": true
         },
         "global-dirs": {
           "version": "0.1.1",
@@ -5707,11 +6188,12 @@
           "bundled": true
         },
         "globby": {
-          "version": "7.1.1",
+          "version": "8.0.1",
           "bundled": true,
           "requires": {
             "array-union": "1.0.2",
             "dir-glob": "2.0.0",
+            "fast-glob": "2.2.0",
             "glob": "7.1.2",
             "ignore": "3.3.7",
             "pify": "3.0.0",
@@ -5719,12 +6201,12 @@
           }
         },
         "google-auth-library": {
-          "version": "1.3.2",
+          "version": "1.4.0",
           "bundled": true,
           "requires": {
             "axios": "0.18.0",
             "gcp-metadata": "0.6.3",
-            "gtoken": "2.2.0",
+            "gtoken": "2.3.0",
             "jws": "3.1.4",
             "lodash.isstring": "4.0.1",
             "lru-cache": "4.1.2",
@@ -5737,23 +6219,23 @@
           "requires": {
             "async": "2.6.0",
             "gcp-metadata": "0.6.3",
-            "google-auth-library": "1.3.2",
+            "google-auth-library": "1.4.0",
             "request": "2.85.0"
           }
         },
         "google-gax": {
-          "version": "0.14.5",
+          "version": "0.16.0",
           "bundled": true,
           "requires": {
+            "duplexify": "3.5.4",
             "extend": "3.0.1",
-            "globby": "7.1.1",
+            "globby": "8.0.1",
             "google-auto-auth": "0.9.7",
-            "google-proto-files": "0.14.2",
-            "grpc": "1.7.3",
-            "is-stream-ended": "0.1.3",
+            "google-proto-files": "0.15.1",
+            "grpc": "1.9.1",
+            "is-stream-ended": "0.1.4",
             "lodash": "4.17.5",
             "protobufjs": "6.8.6",
-            "readable-stream": "2.3.5",
             "through2": "2.0.3"
           }
         },
@@ -5761,18 +6243,31 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "node-forge": "0.7.4",
+            "node-forge": "0.7.5",
             "pify": "3.0.0"
           }
         },
         "google-proto-files": {
-          "version": "0.14.2",
+          "version": "0.15.1",
           "bundled": true,
           "requires": {
             "globby": "7.1.1",
-            "power-assert": "1.4.4",
-            "prettier": "1.11.1",
+            "power-assert": "1.5.0",
             "protobufjs": "6.8.6"
+          },
+          "dependencies": {
+            "globby": {
+              "version": "7.1.1",
+              "bundled": true,
+              "requires": {
+                "array-union": "1.0.2",
+                "dir-glob": "2.0.0",
+                "glob": "7.1.2",
+                "ignore": "3.3.7",
+                "pify": "3.0.0",
+                "slash": "1.0.0"
+              }
+            }
           }
         },
         "got": {
@@ -5787,7 +6282,7 @@
             "into-stream": "3.1.0",
             "is-retry-allowed": "1.1.0",
             "isurl": "1.0.0",
-            "lowercase-keys": "1.0.0",
+            "lowercase-keys": "1.0.1",
             "mimic-response": "1.0.0",
             "p-cancelable": "0.3.0",
             "p-timeout": "2.0.1",
@@ -5824,10 +6319,9 @@
           "bundled": true
         },
         "grpc": {
-          "version": "1.7.3",
+          "version": "1.9.1",
           "bundled": true,
           "requires": {
-            "arguejs": "0.2.3",
             "lodash": "4.17.5",
             "nan": "2.10.0",
             "node-pre-gyp": "0.6.39",
@@ -5835,7 +6329,7 @@
           },
           "dependencies": {
             "abbrev": {
-              "version": "1.0.9",
+              "version": "1.1.1",
               "bundled": true
             },
             "ajv": {
@@ -5968,7 +6462,7 @@
               }
             },
             "debug": {
-              "version": "2.6.8",
+              "version": "2.6.9",
               "bundled": true,
               "requires": {
                 "ms": "2.0.0"
@@ -5987,7 +6481,7 @@
               "bundled": true
             },
             "detect-libc": {
-              "version": "1.0.2",
+              "version": "1.0.3",
               "bundled": true
             },
             "ecc-jsbn": {
@@ -6070,7 +6564,7 @@
               }
             },
             "glob": {
-              "version": "7.1.1",
+              "version": "7.1.2",
               "bundled": true,
               "requires": {
                 "fs.realpath": "1.0.0",
@@ -6137,7 +6631,7 @@
               "bundled": true
             },
             "ini": {
-              "version": "1.3.4",
+              "version": "1.3.5",
               "bundled": true
             },
             "is-fullwidth-code-point": {
@@ -6236,27 +6730,25 @@
               "version": "0.6.39",
               "bundled": true,
               "requires": {
-                "detect-libc": "1.0.2",
+                "detect-libc": "1.0.3",
                 "hawk": "3.1.3",
                 "mkdirp": "0.5.1",
                 "nopt": "4.0.1",
                 "npmlog": "4.1.2",
-                "rc": "1.2.2",
+                "rc": "1.2.4",
                 "request": "2.81.0",
                 "rimraf": "2.6.2",
-                "semver": "5.4.1",
+                "semver": "5.5.0",
                 "tar": "2.2.1",
                 "tar-pack": "3.4.1"
-              },
-              "dependencies": {
-                "nopt": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "abbrev": "1.0.9",
-                    "osenv": "0.1.4"
-                  }
-                }
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1.1.1",
+                "osenv": "0.1.4"
               }
             },
             "npmlog": {
@@ -6322,7 +6814,7 @@
               "requires": {
                 "ascli": "1.0.1",
                 "bytebuffer": "5.0.1",
-                "glob": "7.1.1",
+                "glob": "7.1.2",
                 "yargs": "3.32.0"
               }
             },
@@ -6335,11 +6827,11 @@
               "bundled": true
             },
             "rc": {
-              "version": "1.2.2",
+              "version": "1.2.4",
               "bundled": true,
               "requires": {
                 "deep-extend": "0.4.2",
-                "ini": "1.3.4",
+                "ini": "1.3.5",
                 "minimist": "1.2.0",
                 "strip-json-comments": "2.0.1"
               },
@@ -6388,14 +6880,14 @@
                 "stringstream": "0.0.5",
                 "tough-cookie": "2.3.3",
                 "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "uuid": "3.2.1"
               }
             },
             "rimraf": {
               "version": "2.6.2",
               "bundled": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "7.1.2"
               }
             },
             "safe-buffer": {
@@ -6403,7 +6895,7 @@
               "bundled": true
             },
             "semver": {
-              "version": "5.4.1",
+              "version": "5.5.0",
               "bundled": true
             },
             "set-blocking": {
@@ -6485,7 +6977,7 @@
               "version": "3.4.1",
               "bundled": true,
               "requires": {
-                "debug": "2.6.8",
+                "debug": "2.6.9",
                 "fstream": "1.0.11",
                 "fstream-ignore": "1.0.5",
                 "once": "1.4.0",
@@ -6523,7 +7015,7 @@
               "bundled": true
             },
             "uuid": {
-              "version": "3.1.0",
+              "version": "3.2.1",
               "bundled": true
             },
             "verror": {
@@ -6555,13 +7047,13 @@
           }
         },
         "gtoken": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "bundled": true,
           "requires": {
             "axios": "0.18.0",
             "google-p12-pem": "1.0.2",
             "jws": "3.1.4",
-            "mime": "2.2.0",
+            "mime": "2.2.2",
             "pify": "3.0.0"
           }
         },
@@ -6626,6 +7118,32 @@
             "has-symbol-support-x": "1.4.2"
           }
         },
+        "has-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "1.0.0",
+            "isobject": "3.0.1"
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
         "has-yarn": {
           "version": "1.0.0",
           "bundled": true
@@ -6669,7 +7187,7 @@
             "domutils": "1.7.0",
             "entities": "1.1.1",
             "inherits": "2.0.3",
-            "readable-stream": "2.3.5"
+            "readable-stream": "2.3.6"
           }
         },
         "http-cache-semantics": {
@@ -6761,7 +7279,7 @@
           "version": "1.3.2",
           "bundled": true,
           "requires": {
-            "moment": "2.21.0",
+            "moment": "2.22.0",
             "sanitize-html": "1.18.2"
           }
         },
@@ -6769,11 +7287,11 @@
           "version": "3.3.0",
           "bundled": true,
           "requires": {
-            "ansi-escapes": "3.0.0",
+            "ansi-escapes": "3.1.0",
             "chalk": "2.3.2",
             "cli-cursor": "2.1.0",
             "cli-width": "2.2.0",
-            "external-editor": "2.1.0",
+            "external-editor": "2.2.0",
             "figures": "2.0.0",
             "lodash": "4.17.5",
             "mute-stream": "0.0.7",
@@ -6844,6 +7362,13 @@
           "version": "3.2.1",
           "bundled": true
         },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
         "is-arrayish": {
           "version": "0.2.1",
           "bundled": true
@@ -6873,6 +7398,22 @@
             "ci-info": "1.1.3"
           }
         },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
         "is-dotfile": {
           "version": "1.0.3",
           "bundled": true
@@ -6893,7 +7434,7 @@
           "bundled": true
         },
         "is-extglob": {
-          "version": "1.0.0",
+          "version": "2.1.1",
           "bundled": true
         },
         "is-finite": {
@@ -6915,10 +7456,10 @@
           "bundled": true
         },
         "is-glob": {
-          "version": "2.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "2.1.1"
           }
         },
         "is-installed-globally": {
@@ -6934,10 +7475,19 @@
           "bundled": true
         },
         "is-number": {
-          "version": "2.1.0",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
             "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
           }
         },
         "is-obj": {
@@ -6955,12 +7505,25 @@
             "symbol-observable": "1.2.0"
           }
         },
+        "is-odd": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-number": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
         "is-path-cwd": {
           "version": "1.0.0",
           "bundled": true
         },
         "is-path-in-cwd": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true,
           "requires": {
             "is-path-inside": "1.0.1"
@@ -6976,6 +7539,13 @@
         "is-plain-obj": {
           "version": "1.1.0",
           "bundled": true
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "isobject": "3.0.1"
+          }
         },
         "is-posix-bracket": {
           "version": "0.1.1",
@@ -7006,7 +7576,7 @@
           "bundled": true
         },
         "is-stream-ended": {
-          "version": "0.1.3",
+          "version": "0.1.4",
           "bundled": true
         },
         "is-typedarray": {
@@ -7014,11 +7584,15 @@
           "bundled": true
         },
         "is-url": {
-          "version": "1.2.3",
+          "version": "1.2.4",
           "bundled": true
         },
         "is-utf8": {
           "version": "0.2.1",
+          "bundled": true
+        },
+        "is-windows": {
+          "version": "1.0.2",
           "bundled": true
         },
         "isarray": {
@@ -7030,11 +7604,8 @@
           "bundled": true
         },
         "isobject": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
+          "version": "3.0.1",
+          "bundled": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -7090,7 +7661,7 @@
             "escape-string-regexp": "1.0.5",
             "js2xmlparser": "3.0.0",
             "klaw": "2.0.0",
-            "marked": "0.3.17",
+            "marked": "0.3.19",
             "mkdirp": "0.5.1",
             "requizzle": "0.2.1",
             "strip-json-comments": "2.0.1",
@@ -7113,7 +7684,7 @@
           "bundled": true
         },
         "json-parse-better-errors": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "bundled": true
         },
         "json-schema": {
@@ -7199,11 +7770,8 @@
           }
         },
         "kind-of": {
-          "version": "3.2.2",
-          "bundled": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
+          "version": "6.0.2",
+          "bundled": true
         },
         "klaw": {
           "version": "2.0.0",
@@ -7416,7 +7984,7 @@
           }
         },
         "lowercase-keys": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true
         },
         "lru-cache": {
@@ -7434,12 +8002,23 @@
             "pify": "3.0.0"
           }
         },
+        "map-cache": {
+          "version": "0.2.2",
+          "bundled": true
+        },
         "map-obj": {
           "version": "1.0.1",
           "bundled": true
         },
+        "map-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "object-visit": "1.0.1"
+          }
+        },
         "marked": {
-          "version": "0.3.17",
+          "version": "0.3.19",
           "bundled": true
         },
         "matcher": {
@@ -7574,6 +8153,10 @@
             "estraverse": "4.2.0"
           }
         },
+        "merge2": {
+          "version": "1.2.1",
+          "bundled": true
+        },
         "methmeth": {
           "version": "1.1.0",
           "bundled": true
@@ -7583,26 +8166,26 @@
           "bundled": true
         },
         "micromatch": {
-          "version": "2.3.11",
+          "version": "3.1.10",
           "bundled": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.1",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "mime": {
-          "version": "2.2.0",
+          "version": "2.2.2",
           "bundled": true
         },
         "mime-db": {
@@ -7634,6 +8217,23 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true
+        },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "for-in": "1.0.2",
+            "is-extendable": "1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "2.0.4"
+              }
+            }
+          }
         },
         "mkdirp": {
           "version": "0.5.1",
@@ -7705,7 +8305,7 @@
           "bundled": true
         },
         "moment": {
-          "version": "2.21.0",
+          "version": "2.22.0",
           "bundled": true
         },
         "ms": {
@@ -7746,6 +8346,24 @@
           "version": "2.10.0",
           "bundled": true
         },
+        "nanomatch": {
+          "version": "1.2.9",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "fragment-cache": "0.2.1",
+            "is-odd": "2.0.0",
+            "is-windows": "1.0.2",
+            "kind-of": "6.0.2",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          }
+        },
         "natural-compare": {
           "version": "1.4.0",
           "bundled": true
@@ -7766,7 +8384,7 @@
           }
         },
         "node-forge": {
-          "version": "0.7.4",
+          "version": "0.7.5",
           "bundled": true
         },
         "normalize-package-data": {
@@ -10243,9 +10861,70 @@
           "version": "4.1.1",
           "bundled": true
         },
+        "object-copy": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "copy-descriptor": "0.1.1",
+            "define-property": "0.2.5",
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "5.1.0",
+                  "bundled": true
+                }
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
         "object-keys": {
           "version": "1.0.11",
           "bundled": true
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "isobject": "3.0.1"
+          }
         },
         "object.omit": {
           "version": "2.0.1",
@@ -10253,6 +10932,13 @@
           "requires": {
             "for-own": "0.1.5",
             "is-extendable": "0.1.1"
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isobject": "3.0.1"
           }
         },
         "observable-to-promise": {
@@ -10408,7 +11094,7 @@
                 "is-redirect": "1.0.0",
                 "is-retry-allowed": "1.1.0",
                 "is-stream": "1.1.0",
-                "lowercase-keys": "1.0.0",
+                "lowercase-keys": "1.0.1",
                 "safe-buffer": "5.1.1",
                 "timed-out": "4.0.1",
                 "unzip-response": "2.0.1",
@@ -10425,6 +11111,19 @@
             "is-dotfile": "1.0.3",
             "is-extglob": "1.0.0",
             "is-glob": "2.0.1"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            }
           }
         },
         "parse-json": {
@@ -10436,6 +11135,14 @@
         },
         "parse-ms": {
           "version": "0.1.2",
+          "bundled": true
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "path-dirname": {
+          "version": "1.0.2",
           "bundled": true
         },
         "path-exists": {
@@ -10520,7 +11227,7 @@
               "bundled": true,
               "requires": {
                 "error-ex": "1.3.1",
-                "json-parse-better-errors": "1.0.1"
+                "json-parse-better-errors": "1.0.2"
               }
             }
           }
@@ -10543,8 +11250,12 @@
           "version": "7.0.0",
           "bundled": true
         },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "bundled": true
+        },
         "postcss": {
-          "version": "6.0.20",
+          "version": "6.0.21",
           "bundled": true,
           "requires": {
             "chalk": "2.3.2",
@@ -10559,7 +11270,7 @@
           }
         },
         "power-assert": {
-          "version": "1.4.4",
+          "version": "1.5.0",
           "bundled": true,
           "requires": {
             "define-properties": "1.1.2",
@@ -10573,7 +11284,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "power-assert-context-traversal": "1.1.1"
           }
         },
@@ -10583,7 +11294,7 @@
           "requires": {
             "acorn": "4.0.13",
             "acorn-es7-plugin": "1.1.7",
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
           }
@@ -10592,7 +11303,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "estraverse": "4.2.0"
           }
         },
@@ -10600,7 +11311,7 @@
           "version": "1.4.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "power-assert-context-formatter": "1.1.1",
             "power-assert-context-reducer-ast": "1.1.2",
             "power-assert-renderer-assertion": "1.1.1",
@@ -10625,7 +11336,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "diff-match-patch": "1.0.0",
             "power-assert-renderer-base": "1.1.1",
             "stringifier": "1.3.0",
@@ -10636,7 +11347,7 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "power-assert-renderer-base": "1.1.1",
             "power-assert-util-string-width": "1.1.1",
             "stringifier": "1.3.0"
@@ -10713,7 +11424,7 @@
             "@protobufjs/pool": "1.1.0",
             "@protobufjs/utf8": "1.1.0",
             "@types/long": "3.0.32",
-            "@types/node": "8.9.5",
+            "@types/node": "8.10.3",
             "long": "4.0.0"
           }
         },
@@ -10755,22 +11466,6 @@
             "kind-of": "4.0.0"
           },
           "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
             "kind-of": {
               "version": "4.0.0",
               "bundled": true,
@@ -10827,7 +11522,7 @@
           }
         },
         "readable-stream": {
-          "version": "2.3.5",
+          "version": "2.3.6",
           "bundled": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -10835,7 +11530,7 @@
             "isarray": "1.0.0",
             "process-nextick-args": "2.0.0",
             "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
+            "string_decoder": "1.1.1",
             "util-deprecate": "1.0.2"
           }
         },
@@ -10845,7 +11540,7 @@
           "requires": {
             "graceful-fs": "4.1.11",
             "minimatch": "3.0.4",
-            "readable-stream": "2.3.5",
+            "readable-stream": "2.3.6",
             "set-immediate-shim": "1.0.1"
           }
         },
@@ -10881,8 +11576,16 @@
             "is-equal-shallow": "0.1.3"
           }
         },
+        "regex-not": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "3.0.2",
+            "safe-regex": "1.1.0"
+          }
+        },
         "regexpp": {
-          "version": "1.0.1",
+          "version": "1.1.0",
           "bundled": true
         },
         "regexpu-core": {
@@ -11028,11 +11731,15 @@
           "version": "3.0.0",
           "bundled": true
         },
+        "resolve-url": {
+          "version": "0.2.1",
+          "bundled": true
+        },
         "responselike": {
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "lowercase-keys": "1.0.0"
+            "lowercase-keys": "1.0.1"
           }
         },
         "restore-cursor": {
@@ -11042,6 +11749,10 @@
             "onetime": "2.0.1",
             "signal-exit": "3.0.2"
           }
+        },
+        "ret": {
+          "version": "0.1.15",
+          "bundled": true
         },
         "retry-axios": {
           "version": "0.3.2",
@@ -11092,6 +11803,13 @@
           "version": "5.1.1",
           "bundled": true
         },
+        "safe-regex": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ret": "0.1.15"
+          }
+        },
         "samsam": {
           "version": "1.3.0",
           "bundled": true
@@ -11107,7 +11825,7 @@
             "lodash.isplainobject": "4.0.6",
             "lodash.isstring": "4.0.1",
             "lodash.mergewith": "4.6.1",
-            "postcss": "6.0.20",
+            "postcss": "6.0.21",
             "srcset": "1.0.0",
             "xtend": "4.0.1"
           }
@@ -11134,6 +11852,25 @@
         "set-immediate-shim": {
           "version": "1.0.1",
           "bundled": true
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "split-string": "3.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
         },
         "shebang-command": {
           "version": "1.2.0",
@@ -11184,6 +11921,115 @@
           "version": "1.1.6",
           "bundled": true
         },
+        "snapdragon": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "base": "0.11.2",
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "map-cache": "0.2.2",
+            "source-map": "0.5.7",
+            "source-map-resolve": "0.5.1",
+            "use": "3.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "snapdragon-util": "3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
         "sntp": {
           "version": "2.1.0",
           "bundled": true,
@@ -11202,6 +12048,17 @@
           "version": "0.5.7",
           "bundled": true
         },
+        "source-map-resolve": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "atob": "2.1.0",
+            "decode-uri-component": "0.2.0",
+            "resolve-url": "0.2.1",
+            "source-map-url": "0.4.0",
+            "urix": "0.1.0"
+          }
+        },
         "source-map-support": {
           "version": "0.5.4",
           "bundled": true,
@@ -11214,6 +12071,10 @@
               "bundled": true
             }
           }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "bundled": true
         },
         "spdx-correct": {
           "version": "3.0.0",
@@ -11244,7 +12105,14 @@
           "bundled": true,
           "requires": {
             "async": "2.6.0",
-            "is-stream-ended": "0.1.3"
+            "is-stream-ended": "0.1.4"
+          }
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "3.0.2"
           }
         },
         "sprintf-js": {
@@ -11277,8 +12145,70 @@
           "version": "1.0.1",
           "bundled": true
         },
+        "static-extend": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "0.2.5",
+            "object-copy": "0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
         "stream-events": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "bundled": true,
           "requires": {
             "stubs": "3.0.0"
@@ -11310,7 +12240,7 @@
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
+          "version": "1.1.1",
           "bundled": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -11320,7 +12250,7 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "traverse": "0.6.6",
             "type-name": "2.0.2"
           }
@@ -11379,9 +12309,16 @@
             "methods": "1.1.2",
             "mime": "1.6.0",
             "qs": "6.5.1",
-            "readable-stream": "2.3.5"
+            "readable-stream": "2.3.6"
           },
           "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
             "mime": {
               "version": "1.6.0",
               "bundled": true
@@ -11501,7 +12438,7 @@
           "version": "2.0.3",
           "bundled": true,
           "requires": {
-            "readable-stream": "2.3.5",
+            "readable-stream": "2.3.6",
             "xtend": "4.0.1"
           }
         },
@@ -11523,6 +12460,40 @@
         "to-fast-properties": {
           "version": "1.0.3",
           "bundled": true
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "regex-not": "1.0.2",
+            "safe-regex": "1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1"
+          }
         },
         "tough-cookie": {
           "version": "2.3.4",
@@ -11652,6 +12623,35 @@
             }
           }
         },
+        "union-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "arr-union": "3.1.0",
+            "get-value": "2.0.6",
+            "is-extendable": "0.1.1",
+            "set-value": "0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "to-object-path": "0.3.0"
+              }
+            }
+          }
+        },
         "unique-string": {
           "version": "1.0.0",
           "bundled": true,
@@ -11681,24 +12681,61 @@
           "version": "0.1.1",
           "bundled": true
         },
+        "unset-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-value": "0.3.1",
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "bundled": true,
+              "requires": {
+                "get-value": "2.0.6",
+                "has-values": "0.1.4",
+                "isobject": "2.1.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "bundled": true
+            }
+          }
+        },
         "unzip-response": {
           "version": "2.0.1",
           "bundled": true
         },
         "update-notifier": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "requires": {
             "boxen": "1.3.0",
             "chalk": "2.3.2",
-            "configstore": "3.1.1",
+            "configstore": "3.1.2",
             "import-lazy": "2.1.0",
+            "is-ci": "1.1.0",
             "is-installed-globally": "0.1.0",
             "is-npm": "1.0.0",
             "latest-version": "3.1.0",
             "semver-diff": "2.1.0",
             "xdg-basedir": "3.0.0"
           }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "bundled": true
         },
         "url-parse-lax": {
           "version": "1.0.0",
@@ -11714,6 +12751,13 @@
         "urlgrey": {
           "version": "0.4.4",
           "bundled": true
+        },
+        "use": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -11931,7 +12975,7 @@
       "requires": {
         "end-of-stream": "1.4.1",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "stream-shift": "1.0.0"
       }
     },
@@ -11960,7 +13004,7 @@
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.3"
+        "core-js": "2.5.4"
       }
     },
     "end-of-stream": {
@@ -12008,7 +13052,7 @@
       "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
       "dev": true,
       "requires": {
-        "is-url": "1.2.3",
+        "is-url": "1.2.4",
         "path-is-absolute": "1.0.1",
         "source-map": "0.5.7",
         "xtend": "4.0.1"
@@ -12026,7 +13070,7 @@
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3"
+        "core-js": "2.5.4"
       }
     },
     "estraverse": {
@@ -13149,7 +14193,7 @@
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
       "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
       "requires": {
-        "node-forge": "0.7.4"
+        "node-forge": "0.7.5"
       }
     },
     "got": {
@@ -13164,7 +14208,7 @@
         "is-redirect": "1.0.0",
         "is-retry-allowed": "1.1.0",
         "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
+        "lowercase-keys": "1.0.1",
         "safe-buffer": "5.1.1",
         "timed-out": "4.0.1",
         "unzip-response": "2.0.1",
@@ -13177,83 +14221,73 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "grpc": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.10.0.tgz",
-      "integrity": "sha512-g6Na2dgNusGvSM1ud4hwDaajNP4VSPQhGHnRXzbGNbQJIqGpJhRl7GRgYxTP8rYozqCx2NaT74UL37o8nb0GKA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.10.1.tgz",
+      "integrity": "sha512-xmhA11h2XhqpSVzDAmoQAYdNQ+swILXpKOiRpAEQ2kX55ioxVADc6v7SkS4zQBxm4klhQHgGqpGKvoL6LGx4VQ==",
       "requires": {
         "lodash": "4.17.5",
         "nan": "2.10.0",
-        "node-pre-gyp": "0.6.39",
+        "node-pre-gyp": "0.7.0",
         "protobufjs": "5.0.2"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+          "bundled": true
         },
         "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "version": "5.5.2",
+          "bundled": true,
           "requires": {
             "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "requires": {
             "delegates": "1.0.0",
-            "readable-stream": "2.3.3"
+            "readable-stream": "2.3.5"
           }
         },
         "asn1": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+          "bundled": true
         },
         "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+          "version": "1.0.0",
+          "bundled": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+          "bundled": true
         },
         "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+          "version": "0.7.0",
+          "bundled": true
         },
         "aws4": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+          "bundled": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "bundled": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "tweetnacl": "0.14.5"
@@ -13261,24 +14295,21 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "bundled": true,
           "requires": {
             "inherits": "2.0.3"
           }
         },
         "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "version": "4.3.1",
+          "bundled": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "4.2.1"
           }
         },
         "brace-expansion": {
           "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+          "bundled": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -13286,97 +14317,84 @@
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+          "bundled": true
         },
         "co": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "bundled": true
         },
         "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "version": "1.0.6",
+          "bundled": true,
           "requires": {
             "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+          "bundled": true
         },
         "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "version": "3.1.2",
+          "bundled": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.1"
+              }
+            }
           }
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "bundled": true,
           "requires": {
             "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-            }
           }
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "bundled": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+          "bundled": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+          "bundled": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+          "bundled": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "jsbn": "0.1.1"
@@ -13384,38 +14402,40 @@
         },
         "extend": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+          "bundled": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+          "bundled": true
         },
         "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "version": "2.3.2",
+          "bundled": true,
           "requires": {
             "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+          "bundled": true
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
@@ -13425,8 +14445,7 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "bundled": true,
           "requires": {
             "fstream": "1.0.11",
             "inherits": "2.0.3",
@@ -13435,8 +14454,7 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "requires": {
             "aproba": "1.2.0",
             "console-control-strings": "1.1.0",
@@ -13450,23 +14468,14 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "bundled": true,
           "requires": {
             "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-            }
           }
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -13478,58 +14487,50 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+          "bundled": true
         },
         "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+          "version": "2.0.0",
+          "bundled": true
         },
         "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "version": "5.0.3",
+          "bundled": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
           }
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+          "bundled": true
         },
         "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "version": "6.0.2",
+          "bundled": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.1",
+            "sntp": "2.1.0"
           }
         },
         "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+          "version": "4.2.1",
+          "bundled": true
         },
         "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "version": "1.2.0",
+          "bundled": true,
           "requires": {
-            "assert-plus": "0.2.0",
+            "assert-plus": "1.0.0",
             "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "sshpk": "1.14.1"
           }
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -13537,137 +14538,107 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+          "bundled": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "bundled": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+          "bundled": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "bundled": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+          "bundled": true
         },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "requires": {
-            "jsonify": "0.0.0"
-          }
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+          "bundled": true
         },
         "jsprim": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+          "bundled": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
             "json-schema": "0.2.3",
             "verror": "1.10.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-            }
           }
         },
         "mime-db": {
-          "version": "1.30.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+          "version": "1.33.0",
+          "bundled": true
         },
         "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "version": "2.1.18",
+          "bundled": true,
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "1.33.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "requires": {
             "brace-expansion": "1.1.8"
           }
         },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true
+        },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "requires": {
             "minimist": "0.0.8"
           },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+              "bundled": true
             }
           }
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "bundled": true
         },
         "node-pre-gyp": {
-          "version": "0.6.39",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
-          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+          "version": "0.7.0",
+          "bundled": true,
           "requires": {
             "detect-libc": "1.0.3",
-            "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.2",
-            "rc": "1.2.4",
-            "request": "2.81.0",
+            "rc": "1.2.6",
+            "request": "2.83.0",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
             "tar": "2.2.1",
@@ -13676,17 +14647,15 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "requires": {
             "abbrev": "1.1.1",
-            "osenv": "0.1.4"
+            "osenv": "0.1.5"
           }
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
             "console-control-strings": "1.1.0",
@@ -13696,41 +14665,34 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "bundled": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "requires": {
             "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+          "bundled": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+          "bundled": true
         },
         "osenv": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "version": "0.1.5",
+          "bundled": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -13738,130 +14700,108 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+          "bundled": true
         },
         "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+          "version": "2.1.0",
+          "bundled": true
         },
         "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+          "version": "2.0.0",
+          "bundled": true
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "bundled": true
         },
         "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+          "version": "6.5.1",
+          "bundled": true
         },
         "rc": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.4.tgz",
-          "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
+          "version": "1.2.6",
+          "bundled": true,
           "requires": {
             "deep-extend": "0.4.2",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            }
           }
         },
         "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "version": "2.3.5",
+          "bundled": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
             "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
+            "process-nextick-args": "2.0.0",
             "safe-buffer": "5.1.1",
             "string_decoder": "1.0.3",
             "util-deprecate": "1.0.2"
           }
         },
         "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "version": "2.83.0",
+          "bundled": true,
           "requires": {
-            "aws-sign2": "0.6.0",
+            "aws-sign2": "0.7.0",
             "aws4": "1.6.0",
             "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
+            "combined-stream": "1.0.6",
             "extend": "3.0.1",
             "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
+            "mime-types": "2.1.18",
             "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
             "safe-buffer": "5.1.1",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
+            "tough-cookie": "2.3.4",
             "tunnel-agent": "0.6.0",
             "uuid": "3.2.1"
           }
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "bundled": true,
           "requires": {
             "glob": "7.1.2"
           }
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+          "bundled": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+          "bundled": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+          "bundled": true
         },
         "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "version": "2.1.0",
+          "bundled": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "4.2.1"
           }
         },
         "sshpk": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-          "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+          "version": "1.14.1",
+          "bundled": true,
           "requires": {
             "asn1": "0.2.3",
             "assert-plus": "1.0.0",
@@ -13871,19 +14811,11 @@
             "getpass": "0.1.7",
             "jsbn": "0.1.1",
             "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-            }
           }
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -13892,34 +14824,29 @@
         },
         "string_decoder": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "bundled": true,
           "requires": {
             "safe-buffer": "5.1.1"
           }
         },
         "stringstream": {
           "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+          "bundled": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+          "bundled": true
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "requires": {
             "block-stream": "0.0.9",
             "fstream": "1.0.11",
@@ -13928,85 +14855,68 @@
         },
         "tar-pack": {
           "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
-          "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
+          "bundled": true,
           "requires": {
             "debug": "2.6.9",
             "fstream": "1.0.11",
             "fstream-ignore": "1.0.5",
             "once": "1.4.0",
-            "readable-stream": "2.3.3",
+            "readable-stream": "2.3.5",
             "rimraf": "2.6.2",
             "tar": "2.2.1",
             "uid-number": "0.0.6"
           }
         },
         "tough-cookie": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "version": "2.3.4",
+          "bundled": true,
           "requires": {
             "punycode": "1.4.1"
           }
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "bundled": true,
           "requires": {
             "safe-buffer": "5.1.1"
           }
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "bundled": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
+          "bundled": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+          "bundled": true
         },
         "uuid": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+          "bundled": true
         },
         "verror": {
           "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+          "bundled": true,
           "requires": {
             "assert-plus": "1.0.0",
             "core-util-is": "1.0.2",
             "extsprintf": "1.3.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-            }
           }
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "requires": {
             "string-width": "1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "bundled": true
         }
       }
     },
@@ -14448,9 +15358,9 @@
       "dev": true
     },
     "is-stream-ended": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.3.tgz",
-      "integrity": "sha1-oEc7Jnx1ZjVIa+7cfjNE5UnRUqw="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -14458,9 +15368,9 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-url": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.3.tgz",
-      "integrity": "sha512-vmOHLvzbcnsdFz8wQPXj1lgI5SE8AUlUGMenzuZzRFjoReb1WB+pLt9GrIo7BTker+aTcwrjTDle7odioWeqyw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true
     },
     "is-utf8": {
@@ -14609,9 +15519,9 @@
       "dev": true
     },
     "json-parse-better-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
     "json-schema": {
@@ -14854,9 +15764,9 @@
       }
     },
     "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
     "lru-cache": {
@@ -15091,9 +16001,9 @@
       "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY="
     },
     "node-forge": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.4.tgz",
-      "integrity": "sha512-8Df0906+tq/omxuCZD6PqhPaQDYuyJ1d+VITgxoIA8zvQd1ru+nMJcDChHH324MWitIgbVkAkQoGEEVJNpn/PA=="
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+      "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -15422,7 +16332,7 @@
           "dev": true,
           "requires": {
             "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "pify": {
@@ -15689,16 +16599,16 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
         "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
+        "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
       }
     },
@@ -15710,7 +16620,7 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "set-immediate-shim": "1.0.1"
       }
     },
@@ -16128,7 +17038,7 @@
       "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
       "requires": {
         "async": "2.6.0",
-        "is-stream-ended": "0.1.3"
+        "is-stream-ended": "0.1.4"
       }
     },
     "sprintf-js": {
@@ -16164,9 +17074,9 @@
       "dev": true
     },
     "stream-events": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.2.tgz",
-      "integrity": "sha1-q/OfZsCJCk63lbyNXoWbJhW1kLI=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.3.tgz",
+      "integrity": "sha512-SvnBCMhEBQSJml4/ImlWkzGWgchjo1tVxnoBUOa1i1g3BsYNWz4W6a9Hc8VhqfmwJiEGu6tLrGdNRm/K/I4YXw==",
       "requires": {
         "stubs": "3.0.0"
       }
@@ -16198,9 +17108,9 @@
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -16276,7 +17186,7 @@
         "methods": "1.1.2",
         "mime": "1.6.0",
         "qs": "6.5.1",
-        "readable-stream": "2.3.5"
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "debug": {
@@ -16355,7 +17265,7 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "xtend": "4.0.1"
       }
     },
@@ -16574,15 +17484,16 @@
       "dev": true
     },
     "update-notifier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz",
+      "integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
       "dev": true,
       "requires": {
         "boxen": "1.3.0",
         "chalk": "2.3.2",
-        "configstore": "3.1.1",
+        "configstore": "3.1.2",
         "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
         "is-installed-globally": "0.1.0",
         "is-npm": "1.0.0",
         "latest-version": "3.1.0",


### PR DESCRIPTION
Update google-gax to use newer gRPC. Renovate would've done it for us but it will only come after 10pm and I'd like to have it earlier.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
