### PR TITLE
chore: lock files maintenance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,16 +81,16 @@
       }
     },
     "@google-cloud/common": {
-      "version": "0.18.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.18.3.tgz",
-      "integrity": "sha512-dujCvT/0AP4q88Kcsjn7w51fQRrci8I+JGtcU3d4E/dVwtHO6EiYgTCwrlBmVDCX5PvN9M5Opqs1Ir0treEFjw==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.18.4.tgz",
+      "integrity": "sha512-9c24oHYEK+VmM/9N1PDftg8jIyOZjnT93QtxD362Kgq7ErurcIGeTq9WEPQ/ckQQq9dKYEWk8QRVJvzIbRqMjw==",
       "dev": true,
       "requires": {
         "@types/duplexify": "3.5.0",
         "@types/request": "2.47.0",
         "arrify": "1.0.1",
         "axios": "0.18.0",
-        "duplexify": "3.5.4",
+        "duplexify": "3.6.0",
         "ent": "2.2.0",
         "extend": "3.0.1",
         "google-auth-library": "1.4.0",
@@ -1935,7 +1935,7 @@
       "integrity": "sha512-+aZCCdxuR/Q6n58CBkXyqGqimIqpYUcFLfBXagXv7e9TdJUevqkKhzopBuRz3RB064sQxnJnhttHOkK/O93Ouw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.11"
+        "@types/node": "8.10.12"
       }
     },
     "@types/form-data": {
@@ -1944,7 +1944,7 @@
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.11"
+        "@types/node": "8.10.12"
       }
     },
     "@types/long": {
@@ -1953,9 +1953,9 @@
       "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA=="
     },
     "@types/node": {
-      "version": "8.10.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.11.tgz",
-      "integrity": "sha512-FM7tvbjbn2BUzM/Qsdk9LUGq3zeh7li8NcHoS398dBzqLzfmSqSP1+yKbMRTCcZzLcu2JAR5lq3IKIEYkto7iQ=="
+      "version": "8.10.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.12.tgz",
+      "integrity": "sha512-aRFUGj/f9JVA0qSQiCK9ebaa778mmqMIcy1eKnPktgfm9O6VsnIzzB5wJnjp9/jVrfm7fX1rr3OR1nndppGZUg=="
     },
     "@types/request": {
       "version": "2.47.0",
@@ -1965,7 +1965,7 @@
       "requires": {
         "@types/caseless": "0.12.1",
         "@types/form-data": "2.2.1",
-        "@types/node": "8.10.11",
+        "@types/node": "8.10.12",
         "@types/tough-cookie": "2.3.2"
       }
     },
@@ -2746,7 +2746,7 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "espower-location-detector": "1.0.0",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -2893,7 +2893,7 @@
       "requires": {
         "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.10",
         "mkdirp": "0.5.1",
@@ -2917,7 +2917,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -3270,7 +3270,7 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "deep-equal": "1.0.1",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -3741,9 +3741,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4071,9 +4071,9 @@
       "dev": true
     },
     "duplexify": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
-      "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
         "end-of-stream": "1.4.1",
         "inherits": "2.0.3",
@@ -4109,7 +4109,7 @@
       "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.3.tgz",
       "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "empower-core": "0.6.2"
       }
     },
@@ -4128,7 +4128,7 @@
       "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.5"
+        "core-js": "2.5.6"
       }
     },
     "end-of-stream": {
@@ -4561,7 +4561,7 @@
       "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "requires": {
-        "core-js": "2.5.5"
+        "core-js": "2.5.6"
       }
     },
     "esquery": {
@@ -4732,7 +4732,7 @@
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
-        "iconv-lite": "0.4.21",
+        "iconv-lite": "0.4.22",
         "tmp": "0.0.33"
       }
     },
@@ -4819,7 +4819,7 @@
         "@mrmlnc/readdir-enhanced": "2.2.1",
         "glob-parent": "3.1.0",
         "is-glob": "4.0.0",
-        "merge2": "1.2.1",
+        "merge2": "1.2.2",
         "micromatch": "3.1.10"
       }
     },
@@ -5740,12 +5740,12 @@
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.16.1.tgz",
       "integrity": "sha512-eP7UUkKvaHmmvCrr+rxzkIOeEKOnXmoib7/AkENDAuqlC9T2+lWlzwpthDRnitQcV8SblDMzsk73YPMPCDwPyQ==",
       "requires": {
-        "duplexify": "3.5.4",
+        "duplexify": "3.6.0",
         "extend": "3.0.1",
         "globby": "8.0.1",
         "google-auto-auth": "0.10.1",
         "google-proto-files": "0.15.1",
-        "grpc": "1.11.0",
+        "grpc": "1.11.3",
         "is-stream-ended": "0.1.4",
         "lodash": "4.17.10",
         "protobufjs": "6.8.6",
@@ -5841,29 +5841,19 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.11.0.tgz",
-      "integrity": "sha512-pTJjV/eatBQ6Rhc/jWNmUW9jE8fPrhcMYSWDSyf4l7ah1U3sIe4eIjqI/a3sm0zKbM5CuovV0ESrc+b04kr4Ig==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.11.3.tgz",
+      "integrity": "sha512-7fJ40USpnP7hxGK0uRoEhJz6unA5VUdwInfwAY2rK2+OVxdDJSdTZQ/8/M+1tW68pHZYgHvg2ohvJ+clhW3ANg==",
       "requires": {
         "lodash": "4.17.10",
         "nan": "2.10.0",
-        "node-pre-gyp": "0.7.0",
+        "node-pre-gyp": "0.10.0",
         "protobufjs": "5.0.2"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
           "bundled": true
-        },
-        "ajv": {
-          "version": "5.5.2",
-          "bundled": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -5881,51 +5871,9 @@
             "readable-stream": "2.3.6"
           }
         },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.7.0",
-          "bundled": true
-        },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "4.3.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -5935,24 +5883,13 @@
             "concat-map": "0.0.1"
           }
         },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
+        "chownr": {
+          "version": "1.0.1",
           "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -5966,29 +5903,6 @@
           "version": "1.0.2",
           "bundled": true
         },
-        "cryptiles": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.1"
-              }
-            }
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
@@ -5997,11 +5911,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
+          "version": "0.5.1",
           "bundled": true
         },
         "delegates": {
@@ -6012,65 +5922,16 @@
           "version": "1.0.3",
           "bundled": true
         },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.2",
+        "fs-minipass": {
+          "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
         },
         "gauge": {
           "version": "2.7.4",
@@ -6086,13 +5947,6 @@
             "wide-align": "1.1.2"
           }
         },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
@@ -6105,47 +5959,19 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
-        },
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true
         },
-        "hawk": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.1",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
+        "iconv-lite": {
+          "version": "0.4.19",
           "bundled": true
         },
-        "http-signature": {
-          "version": "1.2.0",
+        "ignore-walk": {
+          "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.1"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -6171,55 +5997,9 @@
             "number-is-nan": "1.0.1"
           }
         },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
         "isarray": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "mime-db": {
-          "version": "1.33.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.18",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.33.0"
-          }
         },
         "minimatch": {
           "version": "3.0.4",
@@ -6231,6 +6011,21 @@
         "minimist": {
           "version": "1.2.0",
           "bundled": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
         },
         "mkdirp": {
           "version": "0.5.1",
@@ -6249,20 +6044,29 @@
           "version": "2.0.0",
           "bundled": true
         },
+        "needle": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.19",
+            "sax": "1.2.4"
+          }
+        },
         "node-pre-gyp": {
-          "version": "0.7.0",
+          "version": "0.10.0",
           "bundled": true,
           "requires": {
             "detect-libc": "1.0.3",
             "mkdirp": "0.5.1",
+            "needle": "2.2.1",
             "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
             "npmlog": "4.1.2",
-            "rc": "1.2.6",
-            "request": "2.83.0",
+            "rc": "1.2.7",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.1"
+            "tar": "4.4.2"
           }
         },
         "nopt": {
@@ -6271,6 +6075,18 @@
           "requires": {
             "abbrev": "1.1.1",
             "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -6285,10 +6101,6 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
           "bundled": true
         },
         "object-assign": {
@@ -6322,10 +6134,6 @@
           "version": "1.0.1",
           "bundled": true
         },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
         "process-nextick-args": {
           "version": "2.0.0",
           "bundled": true
@@ -6341,19 +6149,11 @@
             "yargs": "3.32.0"
           }
         },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "bundled": true
-        },
         "rc": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "deep-extend": "0.4.2",
+            "deep-extend": "0.5.1",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
@@ -6372,34 +6172,6 @@
             "util-deprecate": "1.0.2"
           }
         },
-        "request": {
-          "version": "2.83.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.7.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
-        },
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
@@ -6409,6 +6181,10 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
           "bundled": true
         },
         "semver": {
@@ -6422,27 +6198,6 @@
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        },
-        "sshpk": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
         },
         "string-width": {
           "version": "1.0.2",
@@ -6460,10 +6215,6 @@
             "safe-buffer": "5.1.1"
           }
         },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
@@ -6476,67 +6227,27 @@
           "bundled": true
         },
         "tar": {
-          "version": "2.2.1",
+          "version": "4.4.2",
           "bundled": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            }
           }
-        },
-        "tar-pack": {
-          "version": "3.4.1",
-          "bundled": true,
-          "requires": {
-            "debug": "2.6.9",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.3.6",
-            "rimraf": "2.6.2",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true
         },
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
         },
         "wide-align": {
           "version": "1.1.2",
@@ -6547,6 +6258,10 @@
         },
         "wrappy": {
           "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.2",
           "bundled": true
         }
       }
@@ -6768,9 +6483,9 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+      "version": "0.4.22",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.22.tgz",
+      "integrity": "sha512-1AinFBeDTnsvVEP+V1QBlHpM1UZZl7gWB6fcz7B1Ho+LI1dUh2sSrxoCfVt2PinRHzXAziSniEV3P7JbTDHcXA==",
       "dev": true,
       "requires": {
         "safer-buffer": "2.1.2"
@@ -7910,9 +7625,9 @@
       }
     },
     "merge2": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.1.tgz",
-      "integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
+      "integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
     },
     "methods": {
       "version": "1.1.2",
@@ -11401,7 +11116,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz",
       "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "power-assert-context-traversal": "1.1.1"
       }
     },
@@ -11412,7 +11127,7 @@
       "requires": {
         "acorn": "4.0.13",
         "acorn-es7-plugin": "1.1.7",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
       }
@@ -11422,7 +11137,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.1.1.tgz",
       "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "estraverse": "4.2.0"
       }
     },
@@ -11431,7 +11146,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-formatter/-/power-assert-formatter-1.4.1.tgz",
       "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "power-assert-context-formatter": "1.1.1",
         "power-assert-context-reducer-ast": "1.1.2",
         "power-assert-renderer-assertion": "1.1.1",
@@ -11459,7 +11174,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.1.1.tgz",
       "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "diff-match-patch": "1.0.0",
         "power-assert-renderer-base": "1.1.1",
         "stringifier": "1.3.0",
@@ -11471,7 +11186,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.1.2.tgz",
       "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "power-assert-renderer-base": "1.1.1",
         "power-assert-util-string-width": "1.1.1",
         "stringifier": "1.3.0"
@@ -11568,7 +11283,7 @@
         "@protobufjs/pool": "1.1.0",
         "@protobufjs/utf8": "1.1.0",
         "@types/long": "3.0.32",
-        "@types/node": "8.10.11",
+        "@types/node": "8.10.12",
         "long": "4.0.0"
       }
     },
@@ -11594,9 +11309,9 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
       "version": "5.1.1",
@@ -11871,7 +11586,7 @@
         "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "safe-buffer": "5.1.2",
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.4",
@@ -12509,7 +12224,7 @@
       "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
       "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "traverse": "0.6.6",
         "type-name": "2.0.2"
       }
@@ -12583,7 +12298,7 @@
         "formidable": "1.2.1",
         "methods": "1.1.2",
         "mime": "1.6.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "readable-stream": "2.3.6"
       },
       "dependencies": {

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -81,15 +81,15 @@
       }
     },
     "@google-cloud/common": {
-      "version": "0.18.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.18.3.tgz",
-      "integrity": "sha512-dujCvT/0AP4q88Kcsjn7w51fQRrci8I+JGtcU3d4E/dVwtHO6EiYgTCwrlBmVDCX5PvN9M5Opqs1Ir0treEFjw==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.18.4.tgz",
+      "integrity": "sha512-9c24oHYEK+VmM/9N1PDftg8jIyOZjnT93QtxD362Kgq7ErurcIGeTq9WEPQ/ckQQq9dKYEWk8QRVJvzIbRqMjw==",
       "requires": {
         "@types/duplexify": "3.5.0",
         "@types/request": "2.47.0",
         "arrify": "1.0.1",
         "axios": "0.18.0",
-        "duplexify": "3.5.4",
+        "duplexify": "3.6.0",
         "ent": "2.2.0",
         "extend": "3.0.1",
         "google-auth-library": "1.4.0",
@@ -208,7 +208,7 @@
       "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.5.0.tgz",
       "integrity": "sha512-+aZCCdxuR/Q6n58CBkXyqGqimIqpYUcFLfBXagXv7e9TdJUevqkKhzopBuRz3RB064sQxnJnhttHOkK/O93Ouw==",
       "requires": {
-        "@types/node": "10.0.3"
+        "@types/node": "10.0.4"
       }
     },
     "@types/form-data": {
@@ -216,13 +216,13 @@
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "requires": {
-        "@types/node": "10.0.3"
+        "@types/node": "10.0.4"
       }
     },
     "@types/node": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.3.tgz",
-      "integrity": "sha512-J7nx6JzxmtT4zyvfLipYL7jNaxvlCWpyG7JhhCQ4fQyG+AGfovAHoYR55TFx+X8akfkUJYpt5JG6GPeFMjZaCQ=="
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.4.tgz",
+      "integrity": "sha512-RisaZmcmCLjRipAY7nVi3fmkIk4Z0JMn8YHdGF6qYMsIDpD0dfzz+3yy2dL5Q5aHWOnqPx51IRxkA44myknJvw=="
     },
     "@types/request": {
       "version": "2.47.0",
@@ -231,7 +231,7 @@
       "requires": {
         "@types/caseless": "0.12.1",
         "@types/form-data": "2.2.1",
-        "@types/node": "10.0.3",
+        "@types/node": "10.0.4",
         "@types/tough-cookie": "2.3.2"
       }
     },
@@ -817,7 +817,7 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "espower-location-detector": "1.0.0",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -964,7 +964,7 @@
       "requires": {
         "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.10",
         "mkdirp": "0.5.1",
@@ -988,7 +988,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -1257,7 +1257,7 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "deep-equal": "1.0.1",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -1487,9 +1487,9 @@
       "dev": true
     },
     "colors": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.3.tgz",
-      "integrity": "sha512-qTfM2pNFeMZcLvf/RbrVAzDEVttZjFhaApfx9dplNjvHSX88Ui66zBRb/4YGob/xUWxDceirgoC1lT676asfCQ=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.4.tgz",
+      "integrity": "sha512-6Y+iBnWmXL+AWtlOp2Vr6R2w5MUlNJRwR0ShVFaAb1CqWzhPOpQg4L0jxD+xpw/Nc8QJwaq3KM79QUCriY8CWQ=="
     },
     "colour": {
       "version": "0.7.1",
@@ -1600,9 +1600,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
       "dev": true
     },
     "core-util-is": {
@@ -1806,14 +1806,14 @@
           }
         },
         "@google-cloud/common": {
-          "version": "0.18.3",
+          "version": "0.18.4",
           "bundled": true,
           "requires": {
             "@types/duplexify": "3.5.0",
             "@types/request": "2.47.0",
             "arrify": "1.0.1",
             "axios": "0.18.0",
-            "duplexify": "3.5.4",
+            "duplexify": "3.6.0",
             "ent": "2.2.0",
             "extend": "3.0.1",
             "google-auth-library": "1.4.0",
@@ -3402,14 +3402,14 @@
           "version": "3.5.0",
           "bundled": true,
           "requires": {
-            "@types/node": "8.10.11"
+            "@types/node": "8.10.12"
           }
         },
         "@types/form-data": {
           "version": "2.2.1",
           "bundled": true,
           "requires": {
-            "@types/node": "8.10.11"
+            "@types/node": "8.10.12"
           }
         },
         "@types/long": {
@@ -3417,7 +3417,7 @@
           "bundled": true
         },
         "@types/node": {
-          "version": "8.10.11",
+          "version": "8.10.12",
           "bundled": true
         },
         "@types/request": {
@@ -3426,7 +3426,7 @@
           "requires": {
             "@types/caseless": "0.12.1",
             "@types/form-data": "2.2.1",
-            "@types/node": "8.10.11",
+            "@types/node": "8.10.12",
             "@types/tough-cookie": "2.3.2"
           }
         },
@@ -4065,7 +4065,7 @@
             "babel-generator": "6.26.1",
             "babylon": "6.18.0",
             "call-matcher": "1.0.1",
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "espower-location-detector": "1.0.0",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
@@ -4182,7 +4182,7 @@
           "requires": {
             "babel-core": "6.26.3",
             "babel-runtime": "6.26.0",
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "home-or-tmp": "2.0.0",
             "lodash": "4.17.10",
             "mkdirp": "0.5.1",
@@ -4202,7 +4202,7 @@
           "version": "6.26.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -4495,7 +4495,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "deep-equal": "1.0.1",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
@@ -4865,7 +4865,7 @@
           }
         },
         "core-js": {
-          "version": "2.5.5",
+          "version": "2.5.6",
           "bundled": true
         },
         "core-util-is": {
@@ -5129,7 +5129,7 @@
           "bundled": true
         },
         "duplexify": {
-          "version": "3.5.4",
+          "version": "3.6.0",
           "bundled": true,
           "requires": {
             "end-of-stream": "1.4.1",
@@ -5162,7 +5162,7 @@
           "version": "1.2.3",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "empower-core": "0.6.2"
           }
         },
@@ -5178,7 +5178,7 @@
           "bundled": true,
           "requires": {
             "call-signature": "0.0.2",
-            "core-js": "2.5.5"
+            "core-js": "2.5.6"
           }
         },
         "end-of-stream": {
@@ -5531,7 +5531,7 @@
           "version": "1.7.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5"
+            "core-js": "2.5.6"
           }
         },
         "esquery": {
@@ -5673,7 +5673,7 @@
           "bundled": true,
           "requires": {
             "chardet": "0.4.2",
-            "iconv-lite": "0.4.21",
+            "iconv-lite": "0.4.22",
             "tmp": "0.0.33"
           }
         },
@@ -5749,7 +5749,7 @@
             "@mrmlnc/readdir-enhanced": "2.2.1",
             "glob-parent": "3.1.0",
             "is-glob": "4.0.0",
-            "merge2": "1.2.1",
+            "merge2": "1.2.2",
             "micromatch": "3.1.10"
           }
         },
@@ -6069,12 +6069,12 @@
           "version": "0.16.1",
           "bundled": true,
           "requires": {
-            "duplexify": "3.5.4",
+            "duplexify": "3.6.0",
             "extend": "3.0.1",
             "globby": "8.0.1",
             "google-auto-auth": "0.10.1",
             "google-proto-files": "0.15.1",
-            "grpc": "1.11.0",
+            "grpc": "1.11.3",
             "is-stream-ended": "0.1.4",
             "lodash": "4.17.10",
             "protobufjs": "6.8.6",
@@ -6157,28 +6157,18 @@
           "bundled": true
         },
         "grpc": {
-          "version": "1.11.0",
+          "version": "1.11.3",
           "bundled": true,
           "requires": {
             "lodash": "4.17.10",
             "nan": "2.10.0",
-            "node-pre-gyp": "0.7.0",
+            "node-pre-gyp": "0.10.0",
             "protobufjs": "5.0.2"
           },
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
               "bundled": true
-            },
-            "ajv": {
-              "version": "5.5.2",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
-              }
             },
             "ansi-regex": {
               "version": "2.1.1",
@@ -6196,51 +6186,9 @@
                 "readable-stream": "2.3.6"
               }
             },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.7.0",
-              "bundled": true
-            },
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.1"
-              }
             },
             "brace-expansion": {
               "version": "1.1.11",
@@ -6250,24 +6198,13 @@
                 "concat-map": "0.0.1"
               }
             },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
+            "chownr": {
+              "version": "1.0.1",
               "bundled": true
             },
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
             },
             "concat-map": {
               "version": "0.0.1",
@@ -6281,29 +6218,6 @@
               "version": "1.0.2",
               "bundled": true
             },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {
-                "boom": {
-                  "version": "5.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.2.1"
-                  }
-                }
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
             "debug": {
               "version": "2.6.9",
               "bundled": true,
@@ -6312,11 +6226,7 @@
               }
             },
             "deep-extend": {
-              "version": "0.4.2",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
+              "version": "0.5.1",
               "bundled": true
             },
             "delegates": {
@@ -6327,65 +6237,16 @@
               "version": "1.0.3",
               "bundled": true
             },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.2",
+            "fs-minipass": {
+              "version": "1.2.5",
               "bundled": true,
               "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "minipass": "2.2.4"
               }
             },
             "fs.realpath": {
               "version": "1.0.0",
               "bundled": true
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
-              }
-            },
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "fstream": "1.0.11",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4"
-              }
             },
             "gauge": {
               "version": "2.7.4",
@@ -6401,13 +6262,6 @@
                 "wide-align": "1.1.2"
               }
             },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
             "glob": {
               "version": "7.1.2",
               "bundled": true,
@@ -6420,47 +6274,19 @@
                 "path-is-absolute": "1.0.1"
               }
             },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
-              }
-            },
             "has-unicode": {
               "version": "2.0.1",
               "bundled": true
             },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.1",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.1",
+            "iconv-lite": {
+              "version": "0.4.19",
               "bundled": true
             },
-            "http-signature": {
-              "version": "1.2.0",
+            "ignore-walk": {
+              "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+                "minimatch": "3.0.4"
               }
             },
             "inflight": {
@@ -6486,55 +6312,9 @@
                 "number-is-nan": "1.0.1"
               }
             },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
             "isarray": {
               "version": "1.0.0",
               "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "mime-db": {
-              "version": "1.33.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.18",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.33.0"
-              }
             },
             "minimatch": {
               "version": "3.0.4",
@@ -6546,6 +6326,21 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true
+            },
+            "minipass": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "minipass": "2.2.4"
+              }
             },
             "mkdirp": {
               "version": "0.5.1",
@@ -6564,20 +6359,29 @@
               "version": "2.0.0",
               "bundled": true
             },
+            "needle": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "debug": "2.6.9",
+                "iconv-lite": "0.4.19",
+                "sax": "1.2.4"
+              }
+            },
             "node-pre-gyp": {
-              "version": "0.7.0",
+              "version": "0.10.0",
               "bundled": true,
               "requires": {
                 "detect-libc": "1.0.3",
                 "mkdirp": "0.5.1",
+                "needle": "2.2.1",
                 "nopt": "4.0.1",
+                "npm-packlist": "1.1.10",
                 "npmlog": "4.1.2",
-                "rc": "1.2.6",
-                "request": "2.83.0",
+                "rc": "1.2.7",
                 "rimraf": "2.6.2",
                 "semver": "5.5.0",
-                "tar": "2.2.1",
-                "tar-pack": "3.4.1"
+                "tar": "4.4.2"
               }
             },
             "nopt": {
@@ -6586,6 +6390,18 @@
               "requires": {
                 "abbrev": "1.1.1",
                 "osenv": "0.1.5"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "npm-packlist": {
+              "version": "1.1.10",
+              "bundled": true,
+              "requires": {
+                "ignore-walk": "3.0.1",
+                "npm-bundled": "1.0.3"
               }
             },
             "npmlog": {
@@ -6600,10 +6416,6 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
               "bundled": true
             },
             "object-assign": {
@@ -6637,10 +6449,6 @@
               "version": "1.0.1",
               "bundled": true
             },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
             "process-nextick-args": {
               "version": "2.0.0",
               "bundled": true
@@ -6655,19 +6463,11 @@
                 "yargs": "3.32.0"
               }
             },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
             "rc": {
-              "version": "1.2.6",
+              "version": "1.2.7",
               "bundled": true,
               "requires": {
-                "deep-extend": "0.4.2",
+                "deep-extend": "0.5.1",
                 "ini": "1.3.5",
                 "minimist": "1.2.0",
                 "strip-json-comments": "2.0.1"
@@ -6686,34 +6486,6 @@
                 "util-deprecate": "1.0.2"
               }
             },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.7.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
-              }
-            },
             "rimraf": {
               "version": "2.6.2",
               "bundled": true,
@@ -6723,6 +6495,10 @@
             },
             "safe-buffer": {
               "version": "5.1.1",
+              "bundled": true
+            },
+            "sax": {
+              "version": "1.2.4",
               "bundled": true
             },
             "semver": {
@@ -6736,27 +6512,6 @@
             "signal-exit": {
               "version": "3.0.2",
               "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.1"
-              }
-            },
-            "sshpk": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
             },
             "string-width": {
               "version": "1.0.2",
@@ -6774,10 +6529,6 @@
                 "safe-buffer": "5.1.1"
               }
             },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
@@ -6790,67 +6541,27 @@
               "bundled": true
             },
             "tar": {
-              "version": "2.2.1",
+              "version": "4.4.2",
               "bundled": true,
               "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "chownr": "1.0.1",
+                "fs-minipass": "1.2.5",
+                "minipass": "2.2.4",
+                "minizlib": "1.1.0",
+                "mkdirp": "0.5.1",
+                "safe-buffer": "5.1.2",
+                "yallist": "3.0.2"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
-            },
-            "tar-pack": {
-              "version": "3.4.1",
-              "bundled": true,
-              "requires": {
-                "debug": "2.6.9",
-                "fstream": "1.0.11",
-                "fstream-ignore": "1.0.5",
-                "once": "1.4.0",
-                "readable-stream": "2.3.6",
-                "rimraf": "2.6.2",
-                "tar": "2.2.1",
-                "uid-number": "0.0.6"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.3.4",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true
             },
             "util-deprecate": {
               "version": "1.0.2",
               "bundled": true
-            },
-            "uuid": {
-              "version": "3.2.1",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
             },
             "wide-align": {
               "version": "1.1.2",
@@ -6861,6 +6572,10 @@
             },
             "wrappy": {
               "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
               "bundled": true
             }
           }
@@ -7043,7 +6758,7 @@
           }
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.22",
           "bundled": true,
           "requires": {
             "safer-buffer": "2.1.2"
@@ -7927,7 +7642,7 @@
           }
         },
         "merge2": {
-          "version": "1.2.1",
+          "version": "1.2.2",
           "bundled": true
         },
         "methods": {
@@ -10918,7 +10633,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "power-assert-context-traversal": "1.1.1"
           }
         },
@@ -10928,7 +10643,7 @@
           "requires": {
             "acorn": "4.0.13",
             "acorn-es7-plugin": "1.1.7",
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
           }
@@ -10937,7 +10652,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "estraverse": "4.2.0"
           }
         },
@@ -10945,7 +10660,7 @@
           "version": "1.4.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "power-assert-context-formatter": "1.1.1",
             "power-assert-context-reducer-ast": "1.1.2",
             "power-assert-renderer-assertion": "1.1.1",
@@ -10970,7 +10685,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "diff-match-patch": "1.0.0",
             "power-assert-renderer-base": "1.1.1",
             "stringifier": "1.3.0",
@@ -10981,7 +10696,7 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "power-assert-renderer-base": "1.1.1",
             "power-assert-util-string-width": "1.1.1",
             "stringifier": "1.3.0"
@@ -11058,7 +10773,7 @@
             "@protobufjs/pool": "1.1.0",
             "@protobufjs/utf8": "1.1.0",
             "@types/long": "3.0.32",
-            "@types/node": "8.10.11",
+            "@types/node": "8.10.12",
             "long": "4.0.0"
           }
         },
@@ -11080,7 +10795,7 @@
           "bundled": true
         },
         "qs": {
-          "version": "6.5.1",
+          "version": "6.5.2",
           "bundled": true
         },
         "query-string": {
@@ -11303,7 +11018,7 @@
             "mime-types": "2.1.18",
             "oauth-sign": "0.8.2",
             "performance-now": "2.1.0",
-            "qs": "6.5.1",
+            "qs": "6.5.2",
             "safe-buffer": "5.1.2",
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.4",
@@ -11817,7 +11532,7 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "traverse": "0.6.6",
             "type-name": "2.0.2"
           }
@@ -11875,7 +11590,7 @@
             "formidable": "1.2.1",
             "methods": "1.1.2",
             "mime": "1.6.0",
-            "qs": "6.5.1",
+            "qs": "6.5.2",
             "readable-stream": "2.3.6"
           },
           "dependencies": {
@@ -12530,9 +12245,9 @@
       "dev": true
     },
     "duplexify": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
-      "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
         "end-of-stream": "1.4.1",
         "inherits": "2.0.3",
@@ -12565,7 +12280,7 @@
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.5"
+        "core-js": "2.5.6"
       }
     },
     "end-of-stream": {
@@ -12632,7 +12347,7 @@
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5"
+        "core-js": "2.5.6"
       }
     },
     "estraverse": {
@@ -13515,29 +13230,19 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.11.0.tgz",
-      "integrity": "sha512-pTJjV/eatBQ6Rhc/jWNmUW9jE8fPrhcMYSWDSyf4l7ah1U3sIe4eIjqI/a3sm0zKbM5CuovV0ESrc+b04kr4Ig==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.11.3.tgz",
+      "integrity": "sha512-7fJ40USpnP7hxGK0uRoEhJz6unA5VUdwInfwAY2rK2+OVxdDJSdTZQ/8/M+1tW68pHZYgHvg2ohvJ+clhW3ANg==",
       "requires": {
         "lodash": "4.17.10",
         "nan": "2.10.0",
-        "node-pre-gyp": "0.7.0",
+        "node-pre-gyp": "0.10.0",
         "protobufjs": "5.0.2"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
           "bundled": true
-        },
-        "ajv": {
-          "version": "5.5.2",
-          "bundled": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -13555,51 +13260,9 @@
             "readable-stream": "2.3.6"
           }
         },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.7.0",
-          "bundled": true
-        },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "4.3.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -13609,24 +13272,13 @@
             "concat-map": "0.0.1"
           }
         },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
+        "chownr": {
+          "version": "1.0.1",
           "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -13640,29 +13292,6 @@
           "version": "1.0.2",
           "bundled": true
         },
-        "cryptiles": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.1"
-              }
-            }
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
@@ -13671,11 +13300,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
+          "version": "0.5.1",
           "bundled": true
         },
         "delegates": {
@@ -13686,65 +13311,16 @@
           "version": "1.0.3",
           "bundled": true
         },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.2",
+        "fs-minipass": {
+          "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
         },
         "gauge": {
           "version": "2.7.4",
@@ -13760,13 +13336,6 @@
             "wide-align": "1.1.2"
           }
         },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
@@ -13779,47 +13348,19 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
-        },
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true
         },
-        "hawk": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.1",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
+        "iconv-lite": {
+          "version": "0.4.19",
           "bundled": true
         },
-        "http-signature": {
-          "version": "1.2.0",
+        "ignore-walk": {
+          "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.1"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -13845,55 +13386,9 @@
             "number-is-nan": "1.0.1"
           }
         },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
         "isarray": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "mime-db": {
-          "version": "1.33.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.18",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.33.0"
-          }
         },
         "minimatch": {
           "version": "3.0.4",
@@ -13905,6 +13400,21 @@
         "minimist": {
           "version": "1.2.0",
           "bundled": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
         },
         "mkdirp": {
           "version": "0.5.1",
@@ -13923,20 +13433,29 @@
           "version": "2.0.0",
           "bundled": true
         },
+        "needle": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.19",
+            "sax": "1.2.4"
+          }
+        },
         "node-pre-gyp": {
-          "version": "0.7.0",
+          "version": "0.10.0",
           "bundled": true,
           "requires": {
             "detect-libc": "1.0.3",
             "mkdirp": "0.5.1",
+            "needle": "2.2.1",
             "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
             "npmlog": "4.1.2",
-            "rc": "1.2.6",
-            "request": "2.83.0",
+            "rc": "1.2.7",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.1"
+            "tar": "4.4.2"
           }
         },
         "nopt": {
@@ -13945,6 +13464,18 @@
           "requires": {
             "abbrev": "1.1.1",
             "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -13959,10 +13490,6 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
           "bundled": true
         },
         "object-assign": {
@@ -13996,27 +13523,15 @@
           "version": "1.0.1",
           "bundled": true
         },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
         "process-nextick-args": {
           "version": "2.0.0",
           "bundled": true
         },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "bundled": true
-        },
         "rc": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "deep-extend": "0.4.2",
+            "deep-extend": "0.5.1",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
@@ -14035,34 +13550,6 @@
             "util-deprecate": "1.0.2"
           }
         },
-        "request": {
-          "version": "2.83.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.7.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
-        },
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
@@ -14072,6 +13559,10 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
           "bundled": true
         },
         "semver": {
@@ -14085,27 +13576,6 @@
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        },
-        "sshpk": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
         },
         "string-width": {
           "version": "1.0.2",
@@ -14123,10 +13593,6 @@
             "safe-buffer": "5.1.1"
           }
         },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
@@ -14139,67 +13605,27 @@
           "bundled": true
         },
         "tar": {
-          "version": "2.2.1",
+          "version": "4.4.2",
           "bundled": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            }
           }
-        },
-        "tar-pack": {
-          "version": "3.4.1",
-          "bundled": true,
-          "requires": {
-            "debug": "2.6.9",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.3.6",
-            "rimraf": "2.6.2",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true
         },
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
         },
         "wide-align": {
           "version": "1.1.2",
@@ -14210,6 +13636,10 @@
         },
         "wrappy": {
           "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.2",
           "bundled": true
         }
       }
@@ -17402,7 +16832,7 @@
       "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
       "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
       "requires": {
-        "colors": "1.2.3",
+        "colors": "1.2.4",
         "pkginfo": "0.4.1",
         "read": "1.0.7",
         "revalidator": "0.1.8",
@@ -17468,9 +16898,9 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
       "version": "5.1.1",
@@ -17743,7 +17173,7 @@
         "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "safe-buffer": "5.1.2",
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.4",
@@ -18172,7 +17602,7 @@
         "formidable": "1.2.1",
         "methods": "1.1.2",
         "mime": "1.6.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "readable-stream": "2.3.6"
       },
       "dependencies": {


### PR DESCRIPTION
🔨 update lock files to use the latest gRPC (v1.11.3) and make node10 test use pre-built binary