### PR TITLE
chore(build): use `npm ci` instead of `npm install`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,65 +3,48 @@ workflows:
   version: 2
   tests:
     jobs: &workflow_jobs
-      - node4:
-          filters:
-            tags:
-              only: /.*/
       - node6:
-          filters:
+          filters: &all_commits
             tags:
               only: /.*/
       - node8:
-          filters:
-            tags:
-              only: /.*/
-      - node9:
-          filters:
-            tags:
-              only: /.*/
+          filters: *all_commits
       - node10:
-          filters:
-            tags:
-              only: /.*/
+          filters: *all_commits
       - lint:
           requires:
-            - node4
             - node6
             - node8
-            - node9
             - node10
-          filters:
-            tags:
-              only: /.*/
+          filters: *all_commits
       - docs:
           requires:
-            - node4
             - node6
             - node8
-            - node9
             - node10
-          filters:
-            tags:
-              only: /.*/
+          filters: *all_commits
+      - system_tests:
+          requires:
+            - lint
+            - docs
+          filters: &master_and_releases
+            branches:
+              only: master
+            tags: &releases
+              only: '/^v[\d.]+$/'
       - sample_tests:
           requires:
             - lint
             - docs
-          filters:
-            branches:
-              only:
-                - master
-                - repo-preparation
-            tags:
-              only: '/^v[\d.]+$/'
+          filters: *master_and_releases
       - publish_npm:
           requires:
+            - system_tests
             - sample_tests
           filters:
             branches:
               ignore: /.*/
-            tags:
-              only: '/^v[\d.]+$/'
+            tags: *releases
   nightly:
     triggers:
       - schedule:
@@ -71,10 +54,9 @@ workflows:
               only: master
     jobs: *workflow_jobs
 jobs:
-  node4:
+  node6:
     docker:
-      - image: >-
-          node:4@sha256:e5085d42935eaeff7cc71ddbae191c16838b1554a5d223e8e46cd0383f79796f
+      - image: 'node:6'
         user: node
     steps: &unit_tests_steps
       - checkout
@@ -90,51 +72,28 @@ jobs:
               echo "Not a nightly build, skipping this step."
             fi
       - run: &npm_install_and_link
-          name: Install and link the module.
-          command: |
+          name: Install and link the module
+          command: |-
             mkdir -p /home/node/.npm-global
             npm install
-            repo_tools="node_modules/@google-cloud/nodejs-repo-tools/bin/tools"
-            if ! test -x "$repo_tools"; then
-              chmod +x "$repo_tools"
-            fi
-            npm link
           environment:
             NPM_CONFIG_PREFIX: /home/node/.npm-global
-      - run:
-          name: Run unit tests.
-          command: npm test
-      - run:
-          name: Submit coverage data to codecov.
-          command: node_modules/.bin/codecov
-          when: always
-  node6:
-    docker:
-      - image: >-
-          node:6@sha256:cba697023cd60a65f6f90a9ad2e8d5060620b9a80826c84005244114891f82c1
-        user: node
-    steps: *unit_tests_steps
+      - run: npm test
+      - run: node_modules/.bin/codecov
+  
   node8:
     docker:
-      - image: >-
-          node:8@sha256:b802a02ee6496c34e2dc0eb0379eb1c738331414956d650c0dffdfa0866acb2f
-        user: node
-    steps: *unit_tests_steps
-  node9:
-    docker:
-      - image: >-
-          node:9@sha256:84defd39d4694815086f11e3f293b7dbc3bae0742ad9691824111420954920b1
+      - image: 'node:8'
         user: node
     steps: *unit_tests_steps
   node10:
     docker:
-      - image: 'node:10@sha256:1201e1478ae2146ef699835a5726b1586e954b568962f5f937378d48de2e3014'
+      - image: 'node:10'
         user: node
     steps: *unit_tests_steps
   lint:
     docker:
-      - image: >-
-          node:8@sha256:b802a02ee6496c34e2dc0eb0379eb1c738331414956d650c0dffdfa0866acb2f
+      - image: 'node:8'
         user: node
     steps:
       - checkout
@@ -144,9 +103,8 @@ jobs:
           name: Link the module being tested to the samples.
           command: |
             cd samples/
-            npm link dialogflow
+            npm link ../
             npm install
-            cd ..
           environment:
             NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:
@@ -156,8 +114,7 @@ jobs:
             NPM_CONFIG_PREFIX: /home/node/.npm-global
   docs:
     docker:
-      - image: >-
-          node:8@sha256:b802a02ee6496c34e2dc0eb0379eb1c738331414956d650c0dffdfa0866acb2f
+      - image: 'node:8'
         user: node
     steps:
       - checkout
@@ -168,8 +125,7 @@ jobs:
           command: npm run docs
   sample_tests:
     docker:
-      - image: >-
-          node:8@sha256:b802a02ee6496c34e2dc0eb0379eb1c738331414956d650c0dffdfa0866acb2f
+      - image: 'node:8'
         user: node
     steps:
       - checkout
@@ -187,23 +143,41 @@ jobs:
           command: npm run samples-test
           environment:
             GCLOUD_PROJECT: long-door-651
-            GOOGLE_APPLICATION_CREDENTIALS: /home/node/dialogflow-samples/.circleci/key.json
+            GOOGLE_APPLICATION_CREDENTIALS: /home/node/samples/.circleci/key.json
             NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:
           name: Remove unencrypted key.
           command: rm .circleci/key.json
           when: always
-    working_directory: /home/node/dialogflow-samples
-  publish_npm:
+    working_directory: /home/node/samples/
+  system_tests:
     docker:
-      - image: >-
-          node:8@sha256:b802a02ee6496c34e2dc0eb0379eb1c738331414956d650c0dffdfa0866acb2f
+      - image: 'node:8'
         user: node
     steps:
       - checkout
+      - run: *remove_package_lock
       - run:
-          name: Set NPM authentication.
-          command: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc'
+          name: Decrypt credentials.
+          command: |
+            openssl aes-256-cbc -d -in .circleci/key.json.enc \
+                -out .circleci/key.json \
+                -k "${SYSTEM_TESTS_ENCRYPTION_KEY}"
+      - run: *npm_install_and_link
       - run:
-          name: Publish the module to npm.
-          command: npm publish
+          name: Run system tests.
+          command: npm run system-test
+          environment:
+            GOOGLE_APPLICATION_CREDENTIALS: .circleci/key.json
+      - run:
+          name: Remove unencrypted key.
+          command: rm .circleci/key.json
+          when: always
+  publish_npm:
+    docker:
+      - image: 'node:8'
+        user: node
+    steps:
+      - checkout
+      - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc'
+      - run: npm publish

--- a/synth.py
+++ b/synth.py
@@ -28,7 +28,7 @@ versions = ['v2', 'v2beta1']
 for version in versions:
     library = gapic.node_library('dialogflow', version)
 
-s.copy(library, excludes=['package.json', 'README.md'])
+s.copy(library, excludes=['package.json', 'README.md', 'src/index.js'])
 
 '''
 Node.js specific cleanup

--- a/synth.py
+++ b/synth.py
@@ -23,12 +23,17 @@ import subprocess
 logging.basicConfig(level=logging.DEBUG)
 
 gapic = gcp.GAPICGenerator()
+# create common templates by gapic
+common_templates = gcp.CommonTemplates()
 
 versions = ['v2', 'v2beta1']
 for version in versions:
     library = gapic.node_library('dialogflow', version)
 
 s.copy(library, excludes=['package.json', 'README.md', 'src/index.js'])
+
+templates = common_templates.node_library(package_name="dialogflow")
+s.copy(templates)
 
 '''
 Node.js specific cleanup

--- a/synth.py
+++ b/synth.py
@@ -27,19 +27,13 @@ gapic = gcp.GAPICGenerator()
 versions = ['v2', 'v2beta1']
 for version in versions:
     library = gapic.node_library('dialogflow', version)
-    s.copy(library / 'protos')
-    s.copy(library / 'src' / version)
-    s.copy(library / 'test')
+
+s.copy(library, excludes=['package.json', 'README.md'])
 
 '''
 Node.js specific cleanup
 '''
-# Repo Cleanup/Setup
-subprocess.run(['npm', 'install'])
+subprocess.run(['npm', 'ci'])
 
-# Generates scaffolding, enters contributors names
-subprocess.run(['npm', 'run', 'generate-scaffolding'])
-
-# prettify and lint
 subprocess.run(['npm', 'run', 'prettier'])
 subprocess.run(['npm', 'run', 'lint'])


### PR DESCRIPTION
Bring synth.py up to standard as with other googleapis nodejs repositories