### PR TITLE
chore: drop repo-tools as an exec wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,13 +38,15 @@
   ],
   "scripts": {
     "cover": "nyc --reporter=lcov mocha --require intelli-espower-loader test/*.js && nyc report",
-    "docs": "repo-tools exec -- jsdoc -c .jsdoc.js",
+    "docs": "jsdoc -c .jsdoc.js",
     "generate-scaffolding": "repo-tools generate all && repo-tools generate lib_samples_readme -l samples/ --config ../.cloud-repo-tools.json",
-    "lint": "repo-tools lint --cmd eslint -- src/ samples/ system-test/ test/",
-    "prettier": "repo-tools exec -- prettier --write src/*.js src/*/*.js samples/*.js samples/*/*.js test/*.js test/*/*.js",
+    "lint": "eslint src/ samples/ system-test/ test/",
+    "prettier": "prettier --write src/**/*.js samples/*.js samples/**/*.js system-test/**/*.js test/**/*.js",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
-    "test-no-cover": "repo-tools test run --cmd mocha -- test/*.js --no-timeouts",
-    "test": "repo-tools test run --cmd npm -- run cover"
+    "test-no-cover": "mocha test/",
+    "test": "npm run cover",
+    "system-test": "mocha system-test/ --timeout 600000",
+    "all-test": "npm test && npm run system-test && npm run samples-test"
   },
   "dependencies": {
     "google-gax": "^0.17.1",


### PR DESCRIPTION
We missed dialogflow when we did the org-wide drop of exec-tool (see https://github.com/googleapis/nodejs-storage/pull/258)